### PR TITLE
Upgrade to swift 2.2

### DIFF
--- a/Prelude/Comparable.swift
+++ b/Prelude/Comparable.swift
@@ -6,9 +6,9 @@ extension Comparable {
 
    - returns: A function that takes a value and returns the value clamped to [self, max].
    */
-  public func clamp(max: Self)(_ value: Self) -> Self {
+  public func clamp(max: Self) -> (Self -> Self) {
     assert(self < max)
-    return value < self ? self : value > max ? max : value
+    return { value in value < self ? self : value > max ? max : value }
   }
 }
 
@@ -20,6 +20,6 @@ extension Comparable {
 
  - returns: A function that takes a value and returns the value clamped to [min, max].
  */
-public func clamp <T: Comparable> (min: T, _ max: T)(_ value: T) -> T {
-  return value |> min.clamp(max)
+public func clamp <T: Comparable> (min: T, _ max: T) -> (T -> T) {
+  return { value in value |> min.clamp(max) }
 }

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -1,7 +1,7 @@
 /// An optional protocol for use in type constraints.
 public protocol OptionalType {
   /// The type contained in the otpional.
-  typealias Wrapped
+  associatedtype Wrapped
 
   /// Extracts an optional from the receiver.
   var optional: Wrapped? { get }

--- a/Prelude/Tuple.swift
+++ b/Prelude/Tuple.swift
@@ -1,29 +1,3 @@
-public func == <A: Equatable, B: Equatable> (lhs: (A, B), rhs: (A, B)) -> Bool {
-  return (lhs.0 == rhs.0) && (lhs.1 == rhs.1)
-}
-
-public func != <A: Equatable, B: Equatable> (lhs: (A, B), rhs: (A, B)) -> Bool {
-  return (lhs.0 != rhs.0) || (lhs.1 != rhs.1)
-}
-
-public func == <A: Equatable, B: Equatable, C: Equatable> (lhs: (A, B, C), rhs: (A, B, C)) -> Bool {
-  return (lhs.0 == rhs.0) && (lhs.1 == rhs.1) && (lhs.2 == rhs.2)
-}
-
-public func != <A: Equatable, B: Equatable, C: Equatable> (lhs: (A, B, C), rhs: (A, B, C)) -> Bool {
-  return (lhs.0 != rhs.0) || (lhs.1 != rhs.1) || (lhs.2 != rhs.2)
-}
-
-// swiftlint:disable:next line_length
-public func == <A: Equatable, B: Equatable, C: Equatable, D: Equatable> (lhs: (A, B, C, D), rhs: (A, B, C, D)) -> Bool {
-  return (lhs.0 == rhs.0) && (lhs.1 == rhs.1) && (lhs.2 == rhs.2) && (lhs.3 == rhs.3)
-}
-
-// swiftlint:disable:next line_length
-public func != <A: Equatable, B: Equatable, C: Equatable, D: Equatable> (lhs: (A, B, C, D), rhs: (A, B, C, D)) -> Bool {
-  return (lhs.0 != rhs.0) || (lhs.1 != rhs.1) || (lhs.2 != rhs.2) || (lhs.3 != rhs.3)
-}
-
 public func == <A: Equatable, B: Equatable> (lhs: [(A, B)], rhs: [(A, B)]) -> Bool {
   for (idx, _) in lhs.enumerate() {
     if lhs[idx] != rhs[idx] {

--- a/Prelude/VectorType.swift
+++ b/Prelude/VectorType.swift
@@ -1,7 +1,7 @@
 /// A `VectorType` instance is something that behaves like a linear vector does, i.e. it can be
 /// scaled with numeric values and added to other vectors.
 public protocol VectorType: Equatable {
-  typealias Scalar: NumericType
+  associatedtype Scalar: NumericType
 
   func scale(c: Scalar) -> Self
   func add(v: Self) -> Self
@@ -18,8 +18,8 @@ public extension VectorType {
 
    - returns: A function that interpolates between `self` and `b` as `t` varies from `0` to `1`.
    */
-  public func lerp(b: Self)(_ t: Self.Scalar) -> Self {
-    return self * (Self.Scalar.one() - t) + b * t
+  public func lerp(b: Self) -> (Self.Scalar -> Self) {
+    return { t in self * (Self.Scalar.one() - t) + b * t }
   }
 
   public func subtract(v: Self) -> Self {
@@ -38,8 +38,8 @@ public extension VectorType {
 
  - returns: A function that interpolates between `a` and `b` as `t` varies from `0` to `1`.
  */
-public func lerp <V: VectorType> (a: V, _ b: V)(_ t: V.Scalar) -> V {
-  return a * (V.Scalar.one() - t) + b * t
+public func lerp <V: VectorType> (a: V, _ b: V) -> (V.Scalar -> V) {
+  return { t in a * (V.Scalar.one() - t) + b * t }
 }
 
 public func * <V: VectorType> (v: V, c: V.Scalar) -> V {

--- a/PreludeTests/TupleTests.swift
+++ b/PreludeTests/TupleTests.swift
@@ -2,27 +2,6 @@ import XCTest
 @testable import Prelude
 
 final class TupleTests: XCTestCase {
-
-  func testTupleEquality() {
-    XCTAssert((1, 2) == (1, 2))
-    XCTAssert((1, 2, 3) == (1, 2, 3))
-    XCTAssert((1, 2, 3, 4) == (1, 2, 3, 4))
-  }
-
-  func testTupleInequality() {
-    XCTAssert((1, 2) != (2, 1))
-    XCTAssert((1, 2) != (1, 3))
-
-    XCTAssert((1, 2, 3) != (2, 3, 1))
-    XCTAssert((1, 2, 3) != (1, 3, 2))
-    XCTAssert((1, 2, 3) != (1, 2, 0))
-
-    XCTAssert((1, 2, 3, 4) != (0, 2, 3, 4))
-    XCTAssert((1, 2, 3, 4) != (1, 0, 3, 4))
-    XCTAssert((1, 2, 3, 4) != (1, 2, 0, 4))
-    XCTAssert((1, 2, 3, 4) != (1, 2, 3, 0))
-  }
-
   func testArrayOfTuplesEquality() {
     XCTAssert([(1, 2), (3, 4)] == [(1, 2), (3, 4)])
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 7.2
+    version: 7.3
 test:
   override:
     - bin/test iOS


### PR DESCRIPTION
Swift 2.2 is coming soon, so this upgrades `Prelude` to the new syntaxes and removes deprecations:
- The special curry syntax is being removed, e.g. `(a: A)(b: B) -> C` has been replaced with just `(a: A) -> B -> C`.
- `typealias` has been changed to `associatedtype`.
- Tuples are now equatable, so can get rid of our definitions.
