### PR TITLE
Add a safe subscript to Array.

### DIFF
--- a/Prelude/Array.swift
+++ b/Prelude/Array.swift
@@ -70,3 +70,16 @@ extension Array: Semigroup {
     return self + other
   }
 }
+
+extension Array {
+  /**
+   Safely accesses an element of `self` by checking the bounds.
+
+   - parameter index: Index of an element to try to get.
+
+   - returns: An element if `index` is within bounds and `nil` otherwise.
+   */
+  public subscript(safe index: Int) -> Element? {
+    return index >= 0 && index < self.count ? self[index] : nil
+  }
+}

--- a/PreludeTests/ArrayTest.swift
+++ b/PreludeTests/ArrayTest.swift
@@ -38,4 +38,12 @@ class ArrayTest: XCTestCase {
     XCTAssert([1, 2, 3, 4] == ([1, 2] <> [3, 4]))
     XCTAssert([1, 2].op([3, 4].op([5, 6])) == [1, 2].op([3, 4]).op([5, 6]), "Associativity")
   }
+
+  func testSafeSubscript() {
+    let xs = [1, 2]
+    XCTAssertEqual(1, xs[safe: 0])
+    XCTAssertEqual(2, xs[safe: 1])
+    XCTAssertNil(xs[safe: -1])
+    XCTAssertNil(xs[safe: 2])
+  }
 }


### PR DESCRIPTION
### What

This adds a subscript operator to arrays so that you can do `xs[safe: index]` without worrying about `index` being within the bounds of `xs`.

I'm typically not in favor of this kind of thing, but I think it's legit in the exact times you wanna swallow the error silently (much like `first` and `last`).

In general, I would say it's a code smell to be using `xs[]` at all, and instead one should operate on arrays in a declarative fashion. But sometimes it's necessary, and I think this will come in handy.
