### PR TITLE
Added some free functions for boolean types.

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		A753B55D1C2EE80B00FDB616 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A753B55C1C2EE80B00FDB616 /* UnitTests.swift */; };
 		A753B55F1C2EE86700FDB616 /* TupleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A753B55E1C2EE86700FDB616 /* TupleTests.swift */; };
 		A753B5611C2EEA1400FDB616 /* OptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A753B5601C2EEA1400FDB616 /* OptionalTests.swift */; };
+		A75EC8151CCBEB4F009BEC10 /* BooleanType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75EC8141CCBEB4F009BEC10 /* BooleanType.swift */; };
+		A75EC8161CCBEB4F009BEC10 /* BooleanType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75EC8141CCBEB4F009BEC10 /* BooleanType.swift */; };
+		A75EC8181CCBEB65009BEC10 /* BooleanTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75EC8171CCBEB65009BEC10 /* BooleanTypeTests.swift */; };
+		A75EC8191CCBEB65009BEC10 /* BooleanTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75EC8171CCBEB65009BEC10 /* BooleanTypeTests.swift */; };
 		A75EFFE21C0E7B8E0002C7D2 /* Unit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75EFFE11C0E7B8E0002C7D2 /* Unit.swift */; };
 		A75EFFE41C0E7BF40002C7D2 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75EFFE31C0E7BF40002C7D2 /* Empty.swift */; };
 		A76DDD531C29AEF60073B888 /* VectorTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76DDD521C29AEF60073B888 /* VectorTypeTest.swift */; };
@@ -88,6 +92,8 @@
 		A753B55C1C2EE80B00FDB616 /* UnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitTests.swift; sourceTree = "<group>"; };
 		A753B55E1C2EE86700FDB616 /* TupleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TupleTests.swift; sourceTree = "<group>"; };
 		A753B5601C2EEA1400FDB616 /* OptionalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalTests.swift; sourceTree = "<group>"; };
+		A75EC8141CCBEB4F009BEC10 /* BooleanType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooleanType.swift; sourceTree = "<group>"; };
+		A75EC8171CCBEB65009BEC10 /* BooleanTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooleanTypeTests.swift; sourceTree = "<group>"; };
 		A75EFFE11C0E7B8E0002C7D2 /* Unit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Unit.swift; sourceTree = "<group>"; };
 		A75EFFE31C0E7BF40002C7D2 /* Empty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
 		A76DDD521C29AEF60073B888 /* VectorTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorTypeTest.swift; sourceTree = "<group>"; };
@@ -177,6 +183,7 @@
 				CA0923FB1BB6291900C9EC88 /* Prelude.h */,
 				CA0923FD1BB6291900C9EC88 /* Info.plist */,
 				CAC0795C1BBDBF8F00AFDBF0 /* Array.swift */,
+				A75EC8141CCBEB4F009BEC10 /* BooleanType.swift */,
 				A7F7ADE71C53D27300E39792 /* Comparable.swift */,
 				A7B60BE81BFBF44000B7B7ED /* Dictionary.swift */,
 				A78323AC1CB9615D000B094C /* Either.swift */,
@@ -209,6 +216,7 @@
 				A753B55E1C2EE86700FDB616 /* TupleTests.swift */,
 				A753B55C1C2EE80B00FDB616 /* UnitTests.swift */,
 				A76DDD521C29AEF60073B888 /* VectorTypeTest.swift */,
+				A75EC8171CCBEB65009BEC10 /* BooleanTypeTests.swift */,
 			);
 			path = PreludeTests;
 			sourceTree = "<group>";
@@ -428,6 +436,7 @@
 				A7FD08561C81E1DA00332CCB /* Tuple.swift in Sources */,
 				A7AD8BC01C9DCBC200016122 /* Semigroup.swift in Sources */,
 				A7FD08571C81E1DA00332CCB /* NumericType.swift in Sources */,
+				A75EC8151CCBEB4F009BEC10 /* BooleanType.swift in Sources */,
 				A7FD08581C81E1DA00332CCB /* Dictionary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -439,6 +448,7 @@
 				A7FD086A1C81E24A00332CCB /* TupleTests.swift in Sources */,
 				A7FD086B1C81E24A00332CCB /* ComparableTests.swift in Sources */,
 				A7FD086C1C81E24A00332CCB /* VectorTypeTest.swift in Sources */,
+				A75EC8181CCBEB65009BEC10 /* BooleanTypeTests.swift in Sources */,
 				A7FD086D1C81E24A00332CCB /* FunctionTest.swift in Sources */,
 				A7FD086E1C81E24A00332CCB /* DictionaryTest.swift in Sources */,
 				A7FD086F1C81E24A00332CCB /* UnitTests.swift in Sources */,
@@ -467,6 +477,7 @@
 				CA3DFCD31BDFFB8000D30C27 /* Tuple.swift in Sources */,
 				A7AD8BC11C9DCBC200016122 /* Semigroup.swift in Sources */,
 				A7EFE1521C28B46900F4CFEB /* NumericType.swift in Sources */,
+				A75EC8161CCBEB4F009BEC10 /* BooleanType.swift in Sources */,
 				A7B60BE91BFBF44000B7B7ED /* Dictionary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -478,6 +489,7 @@
 				A753B55F1C2EE86700FDB616 /* TupleTests.swift in Sources */,
 				A7F7ADEA1C53D43400E39792 /* ComparableTests.swift in Sources */,
 				A76DDD531C29AEF60073B888 /* VectorTypeTest.swift in Sources */,
+				A75EC8191CCBEB65009BEC10 /* BooleanTypeTests.swift in Sources */,
 				CA0924081BB6291900C9EC88 /* FunctionTest.swift in Sources */,
 				A7C510881C273FA600C59136 /* DictionaryTest.swift in Sources */,
 				A753B55D1C2EE80B00FDB616 /* UnitTests.swift in Sources */,

--- a/Prelude/BooleanType.swift
+++ b/Prelude/BooleanType.swift
@@ -1,0 +1,11 @@
+public func isTrue(b: BooleanType) -> Bool {
+  return b.boolValue
+}
+
+public func isFalse(b: BooleanType) -> Bool {
+  return !b.boolValue
+}
+
+public func negate(b: BooleanType) -> Bool {
+  return !b.boolValue
+}

--- a/PreludeTests/BooleanTypeTests.swift
+++ b/PreludeTests/BooleanTypeTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import Prelude
+
+final class BooleanTypeTests: XCTestCase {
+
+  func testIsTrue() {
+    XCTAssertTrue(isTrue(true))
+    XCTAssertFalse(isTrue(false))
+  }
+
+  func testIsFalse() {
+    XCTAssertTrue(isFalse(false))
+    XCTAssertFalse(isFalse(true))
+  }
+
+  func testNegate() {
+    XCTAssertTrue(negate(false))
+    XCTAssertFalse(negate(true))
+  }
+}


### PR DESCRIPTION
Really small PR of functions that i think will allow us to do more point-free programming and be more expressive. For example, this allows us to do:

``` swift
xs.filter(isTrue)
```

instead of 

``` swift
xs.filter { $0 }
// or
xs.filter { x in x }
```

I'm using it in my activities PR https://github.com/kickstarter/kickstarter-tv/pull/49 in the following spots:

https://github.com/kickstarter/kickstarter-tv/blob/activity-paginate/Kickstarter-iOS/ViewModels/ActivitiesViewModel.swift#L103

``` swift
    let isCloseToBottom = self.willDisplayRowProperty.signal.ignoreNil()
      .map { row, total in row >= total - 3 }
      .skipRepeats()
      .filter(isTrue) // <---
      .ignoreValues()
```

https://github.com/kickstarter/kickstarter-tv/blob/activity-paginate/Kickstarter-iOS/ViewModels/ActivitiesViewModel.swift#L149-L150

``` swift
    self.showLoggedOutEmptyState = isLoggedIn
      .skipWhile(isTrue) // <---
      .map(negate)       // <---
      .skipRepeats()
```
