### PR TITLE
Fail circleci on swiftlint issues.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,14 @@
 machine:
   xcode:
     version: 7.3
+dependencies:
+  pre:
+    - brew install swiftlint
 test:
   override:
+    - set -o pipefail &&
+      swiftlint lint --strict --reporter json |
+      tee $CIRCLE_ARTIFACTS/swiftlint-report.json
     - bin/test iOS
     - bin/test tvOS
 experimental:


### PR DESCRIPTION
Same thing we did for the main app, but now we can catch switch violations earlier for these frameworks.
