### PR TITLE
Twiddle

### DIFF
--- a/Prelude/LensType.swift
+++ b/Prelude/LensType.swift
@@ -51,7 +51,7 @@ public extension LensType {
 
  - returns: A function that transforms a whole into a new whole with a part replaced.
  */
-public func *~ <L: LensType> (lens: L, part: L.Part) -> (L.Whole -> L.Whole) {
+public func .~ <L: LensType> (lens: L, part: L.Part) -> (L.Whole -> L.Whole) {
   return { whole in lens.set(part, whole) }
 }
 

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -17,7 +17,7 @@ postfix operator <> {}
 infix operator ^* {associativity left precedence 70}
 
 /// Lens set
-infix operator *~ {associativity left precedence 90}
+infix operator .~ {associativity left precedence 90}
 
 /// Lens over
 infix operator %~ {associativity left precedence 90}

--- a/PreludeTests/LensTests.swift
+++ b/PreludeTests/LensTests.swift
@@ -19,11 +19,11 @@ final class LensTests: XCTestCase {
   }
 
   func testLensSetOperator() {
-    XCTAssertEqual(4, (User._id *~ 4)(user).id)
+    XCTAssertEqual(4, (User._id .~ 4)(user).id)
   }
 
   func testLensSetAndCompositionOperatorPrecedence() {
-    XCTAssertEqual(4, (User._location • Location._id *~ 4)(user).location.id)
+    XCTAssertEqual(4, (User._location • Location._id .~ 4)(user).location.id)
   }
 
   func testLensViewOperator() {
@@ -52,8 +52,8 @@ final class LensTests: XCTestCase {
         |> User._id %~ add(10)
         <> User._location • Location._id %~ square
         <> User._location • Location._id %~ add(8)
-        <> User._location • Location._city • City._id *~ 13
-        <> User._name *~ "brando"
+        <> User._location • Location._city • City._id .~ 13
+        <> User._name .~ "brando"
     )
 
     XCTAssertEqual(13,
@@ -61,7 +61,7 @@ final class LensTests: XCTestCase {
         |> User._id %~ add(10)
         <> User._location • Location._id %~ square
         <> User._location • Location._id %~ add(8)
-        <> User._location • Location._city • City._id *~ 13
+        <> User._location • Location._city • City._id .~ 13
         ^* User._location • Location._city • City._id
     )
   }


### PR DESCRIPTION
Looks, we all make mistakes right?

Well I made a mistake.

For some reason I thought Swift didn't allow `.` in operators.

That's why `*~` is the way it is.

Cause in Haskell the infix set [operator](https://www.schoolofhaskell.com/school/to-infinity-and-beyond/pick-of-the-week/a-little-lens-starter-tutorial#actually-there-are-a-whole-lot-of-operators-in-lens---over-100) is `.~`.

But I didn't think it was possible to do in Swift.

Turns out it is.

So now I'm trying to correct that mistake.

I'll correct all 300+ instances of `*~` soon.

Sorrrryyyyyy.
