### PR TITLE
Don't run swiftlint on local builds.

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -541,7 +541,6 @@
 				A7FD08591C81E1DA00332CCB /* Frameworks */,
 				A7FD085A1C81E1DA00332CCB /* Headers */,
 				A7FD085C1C81E1DA00332CCB /* Resources */,
-				A7FD085D1C81E1DA00332CCB /* swiftlint */,
 			);
 			buildRules = (
 			);
@@ -578,7 +577,6 @@
 				CA0923F41BB6291900C9EC88 /* Frameworks */,
 				CA0923F51BB6291900C9EC88 /* Headers */,
 				CA0923F61BB6291900C9EC88 /* Resources */,
-				A7E19CF31C5332EA00E09C5D /* swiftlint */,
 			);
 			buildRules = (
 			);
@@ -719,37 +717,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		A7E19CF31C5332EA00E09C5D /* swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-		A7FD085D1C81E1DA00332CCB /* swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A70969031D14373400DB39D3 /* Sources */ = {


### PR DESCRIPTION
Let's not run swiftlint locally, and instead only in circle. It can still be run locally by doing `swiftlint` from the command line.

By doing this on all of our targets we'll reduce the incremental build time by about 6 seconds, but most importantly is it will be near instant (~.15 seconds).
