### PR TITLE
Add layoutMargin lens

### DIFF
--- a/Prelude-UIKit/lenses/UIViewControllerLenses.swift
+++ b/Prelude-UIKit/lenses/UIViewControllerLenses.swift
@@ -45,6 +45,10 @@ extension LensType where Whole: UIViewControllerProtocol, Part == UIView {
     return Whole.lens.view • Part.lens.backgroundColor
   }
 
+  public var layoutMargins: Lens<Whole, UIEdgeInsets> {
+    return Whole.lens.view • Part.lens.layoutMargins
+  }
+
   public var tintColor: Lens<Whole, UIColor> {
     return Whole.lens.view • Part.lens.tintColor
   }


### PR DESCRIPTION
Adding this lens to help out with setting `UIViewController` layout margins. Inspired by a vc's need for:

``` swift
self
  |> UIViewController.lens.view.layoutMargins %~~ { _, view in
    view.traitCollection.isRegularRegular 
      ? .init(all: Styles.grid(20)) 
      : .init(all: Styles.grid(3)) 
}
```
