### PR TITLE
Change to optimization settings.

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -1174,7 +1174,6 @@
 				INFOPLIST_FILE = Prelude/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-Xfrontend -debug-time-function-bodies -Onone";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Prelude-UIKit-iOS";
 				PRODUCT_NAME = Prelude_UIKit;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Found this time http://stackoverflow.com/questions/25537614/why-is-swift-compile-time-so-slow/40370475#40370475 on stackoverflow, and was able to cut 60 seconds off a fresh build on the whole app. Gonna apply this to all of our repos...