### PR TITLE
Xcode warnings for functions that take too long to compile

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -1152,7 +1152,6 @@
 				PRODUCT_NAME = Prelude_UIKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1227,7 +1226,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.Prelude;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1320,7 +1318,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -debug-time-function-bodies";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=100";
 				PRODUCT_NAME = Prelude;
 				PROVISIONING_PROFILE_SPECIFIER = 48YBP49Y5N/;
 				SDKROOT = appletvos;
@@ -1370,7 +1368,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -debug-time-function-bodies";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=100";
 				PRODUCT_NAME = Prelude;
 				PROVISIONING_PROFILE_SPECIFIER = 48YBP49Y5N/;
 				SDKROOT = appletvos;

--- a/circle.yml
+++ b/circle.yml
@@ -19,11 +19,11 @@ test:
       swiftlint lint --strict --reporter json |
       tee $CIRCLE_ARTIFACTS/swiftlint-report.json
     - bin/test iOS 9.3
-    - bin/test iOS 10.1
+    - bin/test iOS 10.2
     - bin/test UIKit-iOS 9.3
-    - bin/test UIKit-iOS 10.1
-    - bin/test tvOS 10.1
-    - bin/test UIKit-tvOS 10.1
+    - bin/test UIKit-iOS 10.2
+    - bin/test tvOS 10.0
+    - bin/test UIKit-tvOS 10.0
 experimental:
   notify:
     branches:


### PR DESCRIPTION
Went down a lil bit of a rabbit hole this morning with swift compiler times, and I remembered that swift 3 has a fancy new flag that will put up an Xcode warning if a function takes longer than a certain threshold to compile. I've set that threshold to 100ms for now, and all of our code checks out!
