### PR TITLE
Public initializer for Comparator

### DIFF
--- a/Prelude/Comparator.swift
+++ b/Prelude/Comparator.swift
@@ -31,13 +31,3 @@ extension Comparator : Monoid {
     return Comparator { lhs, rhs in self.compare(lhs, rhs) <> other.compare(lhs, rhs) }
   }
 }
-
-extension Bool {
-  public static let trueLessThanComparator = Comparator<Bool>.init { lhs, rhs in
-    switch (lhs, rhs) {
-    case (true, false):                 return .lt
-    case (false, true):                 return .gt
-    case (true, true), (false, false):  return .eq
-    }
-  }
-}

--- a/Prelude/Comparator.swift
+++ b/Prelude/Comparator.swift
@@ -1,6 +1,10 @@
 public struct Comparator<A> {
   public let compare: (A, A) -> Ordering
 
+  public init(compare: @escaping (A, A) -> Ordering) {
+    self.compare = compare
+  }
+
   /**
    Compare if two elements of the same type are ordered.
 
@@ -25,5 +29,15 @@ extension Comparator : Monoid {
 
   public func op(_ other: Comparator) -> Comparator {
     return Comparator { lhs, rhs in self.compare(lhs, rhs) <> other.compare(lhs, rhs) }
+  }
+}
+
+extension Bool {
+  public static let trueLessThanComparator = Comparator<Bool>.init { lhs, rhs in
+    switch (lhs, rhs) {
+    case (true, false):                 return .lt
+    case (false, true):                 return .gt
+    case (true, true), (false, false):  return .eq
+    }
   }
 }

--- a/Prelude/LensType.swift
+++ b/Prelude/LensType.swift
@@ -53,6 +53,14 @@ public extension LensType where Part : Comparable {
   }
 }
 
+public extension LensType {
+  public func lift(comparator: Comparator<Part>) -> Comparator<Whole> {
+    return Comparator<Whole> { lhs, rhs in
+      return comparator.compare(self.view(lhs), self.view(rhs))
+    }
+  }
+}
+
 /**
  Infix operator of the `set` function.
 

--- a/Prelude/LensType.swift
+++ b/Prelude/LensType.swift
@@ -53,14 +53,6 @@ public extension LensType where Part : Comparable {
   }
 }
 
-public extension LensType {
-  public func lift(comparator: Comparator<Part>) -> Comparator<Whole> {
-    return Comparator<Whole> { lhs, rhs in
-      return comparator.compare(self.view(lhs), self.view(rhs))
-    }
-  }
-}
-
 /**
  Infix operator of the `set` function.
 


### PR DESCRIPTION
In some of the work Im doing for live streams, it will be useful to have a public initializer for comparators. basically, we have an array of live streams with some very complicated sorting logic (e.g. live ones first, then future ones, then recent ones, sorted by start date). this will make it easy to build up comparators that are then composed with the monoidal operation `<>`.