### PR TITLE
Added @discardableResult to some functions

### DIFF
--- a/Prelude/Function.swift
+++ b/Prelude/Function.swift
@@ -6,9 +6,13 @@
 
  - returns: The value from apply `f` to `x`.
  */
-@discardableResult
 public func |> <A, B> (x: A, f: (A) -> B) -> B {
   return f(x)
+}
+
+@discardableResult
+public func *|> <A, B> (x: A, f: (A) -> B) -> B {
+  return x |> f
 }
 
 /**
@@ -19,7 +23,6 @@ public func |> <A, B> (x: A, f: (A) -> B) -> B {
 
  - returns: An array of transformed values.
  */
-@discardableResult
 public func ||> <A, B> (xs: [A], f: (A) -> B) -> [B] {
   return xs.map(f)
 }
@@ -32,7 +35,6 @@ public func ||> <A, B> (xs: [A], f: (A) -> B) -> [B] {
 
  - returns: An optional transformed value.
  */
-@discardableResult
 public func ?|> <A, B> (x: A?, f: (A) -> B) -> B? {
   return x.map(f)
 }
@@ -45,7 +47,6 @@ public func ?|> <A, B> (x: A?, f: (A) -> B) -> B? {
 
  - returns: A function that is the composition of `f` and `g`.
  */
-@discardableResult
 public func • <A, B, C> (g: @escaping (B) -> C, f: @escaping (A) -> B) -> ((A) -> C) {
   return { x in g(f(x)) }
 }
@@ -59,7 +60,6 @@ public func • <A, B, C> (g: @escaping (B) -> C, f: @escaping (A) -> B) -> ((A)
 
  - returns: A function that is the composition of `f` and `g`.
  */
-@discardableResult
 public func <> <A> (f: @escaping (A) -> A, g: @escaping (A) -> A) -> ((A) -> A) {
   return { g(f($0)) }
 }

--- a/Prelude/Function.swift
+++ b/Prelude/Function.swift
@@ -6,6 +6,7 @@
 
  - returns: The value from apply `f` to `x`.
  */
+@discardableResult
 public func |> <A, B> (x: A, f: (A) -> B) -> B {
   return f(x)
 }
@@ -18,6 +19,7 @@ public func |> <A, B> (x: A, f: (A) -> B) -> B {
 
  - returns: An array of transformed values.
  */
+@discardableResult
 public func ||> <A, B> (xs: [A], f: (A) -> B) -> [B] {
   return xs.map(f)
 }
@@ -30,6 +32,7 @@ public func ||> <A, B> (xs: [A], f: (A) -> B) -> [B] {
 
  - returns: An optional transformed value.
  */
+@discardableResult
 public func ?|> <A, B> (x: A?, f: (A) -> B) -> B? {
   return x.map(f)
 }
@@ -42,6 +45,7 @@ public func ?|> <A, B> (x: A?, f: (A) -> B) -> B? {
 
  - returns: A function that is the composition of `f` and `g`.
  */
+@discardableResult
 public func • <A, B, C> (g: @escaping (B) -> C, f: @escaping (A) -> B) -> ((A) -> C) {
   return { x in g(f(x)) }
 }
@@ -55,6 +59,7 @@ public func • <A, B, C> (g: @escaping (B) -> C, f: @escaping (A) -> B) -> ((A)
 
  - returns: A function that is the composition of `f` and `g`.
  */
+@discardableResult
 public func <> <A> (f: @escaping (A) -> A, g: @escaping (A) -> A) -> ((A) -> A) {
   return { g(f($0)) }
 }

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -17,6 +17,9 @@ precedencegroup LensSetPrecedence {
 /// Pipe forward function application.
 infix operator |> : LeftApplyPrecendence
 
+/// Pipe forward function application with discardable result.
+infix operator *|> : LeftApplyPrecendence
+
 /// Infix, flipped version of fmap (for arrays), i.e. `xs ||> f := f <^> xs`
 infix operator ||> : LeftApplyPrecendence
 


### PR DESCRIPTION
Perhaps there's a good reason why we don't want to do this but I thought I'd open the PR anyway so that we can have the conversation 😄.

Just feels like it'd be nice to not have to use `_ =` everywhere?