### PR TITLE
Optional: Applicative

### DIFF
--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -1,4 +1,4 @@
-precedencegroup LeftApplyPrecendence {
+precedencegroup LeftApplyPrecedence {
   associativity: left
   higherThan: AssignmentPrecedence
   lowerThan: TernaryPrecedence
@@ -6,7 +6,7 @@ precedencegroup LeftApplyPrecendence {
 
 precedencegroup FunctionCompositionPrecedence {
   associativity: right
-  higherThan: LeftApplyPrecendence
+  higherThan: LeftApplyPrecedence
 }
 
 precedencegroup LensSetPrecedence {
@@ -15,13 +15,13 @@ precedencegroup LensSetPrecedence {
 }
 
 /// Pipe forward function application.
-infix operator |> : LeftApplyPrecendence
+infix operator |> : LeftApplyPrecedence
 
 /// Infix, flipped version of fmap (for arrays), i.e. `xs ||> f := f <^> xs`
-infix operator ||> : LeftApplyPrecendence
+infix operator ||> : LeftApplyPrecedence
 
 /// Infix, flipped version of fmap (for optionals), i.e. `x ?|> f := f <^> x`
-infix operator ?|> : LeftApplyPrecendence
+infix operator ?|> : LeftApplyPrecedence
 
 /// Composition
 infix operator • : FunctionCompositionPrecedence
@@ -36,7 +36,7 @@ prefix operator <>
 postfix operator <>
 
 /// Lens view
-infix operator ^* : LeftApplyPrecendence
+infix operator ^* : LeftApplyPrecedence
 
 /// Lens set
 infix operator .~ : LensSetPrecedence
@@ -52,3 +52,6 @@ infix operator <>~ : LensSetPrecedence
 
 /// Kleisli lens composition
 infix operator >•>
+
+/// Applicative
+infix operator <*> : LeftApplyPrecedence

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -156,3 +156,15 @@ public func pure<A>(_ x: A) -> A? {
 public func <*> <A, B> (f: ((A) -> B)?, x: A?) -> B? {
   return zip(f, x).map { f, x in f(x) }
 }
+
+public func lift<A, B>(_ f: (A) -> B, _ x: A?) -> B? {
+  return x.map(f)
+}
+
+public func lift<A, B, C>(_ f: (A, B) -> C, _ x: A?, _ y: B?) -> C? {
+  return zip(x, y).map(f)
+}
+
+public func lift<A, B, C, D>(_ f: (A, B, C) -> D, _ x: A?, _ y: B?, _ z: C?) -> D? {
+  return zip(x, y, z).map(f)
+}

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -1,3 +1,4 @@
+
 /// An optional protocol for use in type constraints.
 public protocol OptionalType {
   /// The type contained in the optional.
@@ -125,4 +126,33 @@ public func != <A: Equatable> (lhs: [A?], rhs: [A?]) -> Bool {
 @available(*, deprecated, message: "Don’t use this. It was only necessary for Swift 2.3.")
 public func optionalize<A>(x: A?) -> A? {
   return x
+}
+
+public func zip<A, B>(_ a: A?, _ b: B?) -> (A, B)? {
+  return a.flatMap { a in b.map { b in (a, b) } }
+}
+
+public func zip<A, B, C>(_ a: A?, _ b: B?, _ c: C?) -> (A, B, C)? {
+  return zip(a, b).flatMap { a, b in c.map { c in (a, b, c) } }
+}
+
+/**
+ Applicative `pure`. Wraps a value in an optional.
+
+ - parameter x: A value.
+ */
+public func pure<A>(_ x: A) -> A? {
+  return .some(x)
+}
+
+/**
+ Applicative `ap`. Applies an optional value to an optional function.
+
+ - parameter f: An optional function.
+ - parameter x: An optional value.
+
+ - returns: An optional result of `f` applying `x`.
+ */
+public func <*> <A, B> (f: ((A) -> B)?, x: A?) -> B? {
+  return zip(f, x).map { f, x in f(x) }
 }

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -1,4 +1,3 @@
-
 /// An optional protocol for use in type constraints.
 public protocol OptionalType {
   /// The type contained in the optional.

--- a/Prelude/OptionalTests.swift
+++ b/Prelude/OptionalTests.swift
@@ -76,4 +76,32 @@ final class OptionalTests: XCTestCase {
     XCTAssertEqual(flattenOptional(x), Int?.some(1))
     XCTAssertEqual(flattenOptional(y), Int?.none)
   }
+
+  func testZip() {
+    let pair = zip(.some(1), .some(2))
+    XCTAssertEqual(1, pair?.0)
+    XCTAssertEqual(2, pair?.1)
+    let triple = zip(.some(1), .some(2), .some(3))
+    XCTAssertEqual(1, triple?.0)
+    XCTAssertEqual(2, triple?.1)
+    XCTAssertEqual(3, triple?.2)
+
+    let failFirst: (Int, Int)? = zip(.none, .some(1))
+    XCTAssertNil(failFirst)
+    let failLast: (Int, Int)? = zip(.some(1), .none)
+    XCTAssertNil(failLast)
+    let failTriple: (Int, Int, Int)? = zip(.some(1), .some(2), .none)
+    XCTAssertNil(failTriple)
+  }
+
+  func testPure() {
+    XCTAssertEqual(.some(1), pure(1))
+  }
+
+  func testAp() {
+    let add: (Int) -> (Int) -> Int = { x in { y in x + y } }
+
+    XCTAssertEqual(.some(3), pure(add) <*> .some(1) <*> .some(2))
+    XCTAssertNil(pure(add) <*> .none <*> .some(2))
+  }
 }


### PR DESCRIPTION
![slack-imgs](https://cloud.githubusercontent.com/assets/658/24812514/61666572-1b98-11e7-8f1d-e7c91aa5ccfd.png)

Adds `pure`, `<*>`, `lift` and `zip` to `Optional`. Should allow us to be more functionally expressive.