### PR TITLE
Added >>> and <<< operators. Deprecated •.

### DIFF
--- a/Prelude.playground/Pages/02-Function.swift.xcplaygroundpage/Contents.swift
+++ b/Prelude.playground/Pages/02-Function.swift.xcplaygroundpage/Contents.swift
@@ -1,15 +1,15 @@
 import Prelude
 
 /*:
-# Function.swift
+ # Function.swift
 
----
+ ---
 
-## Functional composition operators
+ ## Functional composition operators
 
-The operators `|>` and `•` can be used for function application and composition in a
-more expressive manner. Let’s define some simple, pure functions:
-*/
+ The operators `|>`, `>>>` and `<<<` can be used for function application and composition in a
+ more expressive manner. Let’s define some simple, pure functions:
+ */
 
 func square (x: Int) -> Int {
   return x * x
@@ -35,37 +35,38 @@ func isEven (n: Int) -> Bool {
 }
 
 /*:
-The "pipe-forward" operator `|>` can be used to send a value through a pipeline of functions:
-*/
+ The "pipe-forward" operator `|>` can be used to send a value through a pipeline of functions:
+ */
 
 5 |> square |> incr |> isPrime
 6 |> square |> incr |> isPrime
 
 /*:
-This is expressing that `5^2 + 1` is not prime, whereas `6^2 + 1` is prime.
+ This is expressing that `5^2 + 1` is not prime, whereas `6^2 + 1` is prime.
 
-Note that `|>` is left-associative, so the above is equivalent to:
-*/
+ Note that `|>` is left-associative, so the above is equivalent to:
+ */
 
 ((5 |> square) |> incr) |> isPrime
 ((6 |> square) |> incr) |> isPrime
 
 /*:
-Alternatively we could have also composed the functions first and then piped a value through.
-Function composition is done via the `•` operator, which can be entered on a keyboard via the
-shortcut `alt+8`. An important property of function composition is that it is expressed
-backwards: `(g • f)(x) == g(f(x))`.
-*/
+ Alternatively we could have also composed the functions first and then piped a value through.
+ Function composition is done via the `>>>` and `<<<` operators.
+ */
 
-5 |> (isPrime • incr • square)
-6 |> (isPrime • incr • square)
+5 |> (square >>> incr >>> isPrime)
+6 |> (square >>> incr >>> isPrime)
+
+5 |> (isPrime <<< incr <<< square)
+6 |> (isPrime <<< incr <<< square)
 
 /*:
  It can also be useful to pipe a whole collection of values into a pipeline, and get the
  resulting collection of transformed values back:
  */
 
-[5, 6, 7, 8, 9, 10] ||> (isPrime • incr • square)
+[5, 6, 7, 8, 9, 10] ||> (square >>> incr >>> isPrime)
 
 /*:
  Or an optional:
@@ -74,66 +75,66 @@ backwards: `(g • f)(x) == g(f(x))`.
 let n: Int? = nil
 let m: Int? = 5
 
-n ?|> (isPrime • incr • square)
-m ?|> (isPrime • incr • square)
+n ?|> (square >>> incr >>> isPrime)
+m ?|> (square >>> incr >>> isPrime)
 
 /*:
-There are two global functions in Function.swift that at first might not seem very useful:
-`id` and `const`. Our goal is to to promote functions and composition above all else, and
-these functions help us do that.
+ There are two global functions in Function.swift that at first might not seem very useful:
+ `id` and `const`. Our goal is to to promote functions and composition above all else, and
+ these functions help us do that.
 
-`id` is a function that simply returns whatever it is fed, i.e. the identity function. Consider
-the problem of filtering an array of booleans to get only the `true` values. One might do:
-*/
+ `id` is a function that simply returns whatever it is fed, i.e. the identity function. Consider
+ the problem of filtering an array of booleans to get only the `true` values. One might do:
+ */
 
 let truths = [true, false, true, true, true, false, false]
 truths.filter { x in x }
 truths.filter { $0 }
 
 /*:
-Neither of those closures are particularly enlightening and both are ad hoc. We could instead
-use the global `id` function to simply write:
-*/
+ Neither of those closures are particularly enlightening and both are ad hoc. We could instead
+ use the global `id` function to simply write:
+ */
 
 truths.filter(id)
 
 /*:
-In fact, anytime you find yourself writing a closure of the form `{ x in x }` or `{ $0 }` you
-can simply use `id`.
+ In fact, anytime you find yourself writing a closure of the form `{ x in x }` or `{ $0 }` you
+ can simply use `id`.
 
-Many times in stream processing one wants to convert a stream of unimportant values into a stream
-of constant values, e.g. a stream of click events on a "Increment" button would be converted to
-a stream of `1`'s. This would typically look like:
-*/
+ Many times in stream processing one wants to convert a stream of unimportant values into a stream
+ of constant values, e.g. a stream of click events on a "Increment" button would be converted to
+ a stream of `1`'s. This would typically look like:
+ */
 
 let clicks = [(), (), (), (), ()]
 let increments = clicks.map { _ in 1}
 
 /*:
-A better way is to use the `const` function, which is a curried function such that `const(x)` returns
-a new function for which no matter what you plug into it, it will simply return `x`. We can now do:
-*/
+ A better way is to use the `const` function, which is a curried function such that `const(x)` returns
+ a new function for which no matter what you plug into it, it will simply return `x`. We can now do:
+ */
 
 let newIncrements = clicks.map(const(1))
 
 /*:
-Anytime you find yourself writing a closure of the form `{ _ in value }` you could instead compose
-with `const(value)`.
+ Anytime you find yourself writing a closure of the form `{ _ in value }` you could instead compose
+ with `const(value)`.
 
-## Point-free programming
+ ## Point-free programming
 
-When one properly prompotes functional composition one can begin transforming streams of data without
-ever explicitly mentioning values in the stream. This is called
-[point-free programming](https://en.wikipedia.org/wiki/Tacit_programming). Consider the following:
-*/
+ When one properly prompotes functional composition one can begin transforming streams of data without
+ ever explicitly mentioning values in the stream. This is called
+ [point-free programming](https://en.wikipedia.org/wiki/Tacit_programming). Consider the following:
+ */
 
 Array(1...100)
-  .map(incr • square)
+  .map(square >>> incr)
   .filter(isPrime)
 
 /*:
-This finds all the prime numbers of the form `n^2 + 1` for `n = 1...100`. The entire stream processing
-pipeline is expressed without ever mentioning a single value that goes through the pipeline. This style
-of programming is very expressive and forces one to think in terms of small atomic units and pure
-functions, the benefits of which are immense.
-*/
+ This finds all the prime numbers of the form `n^2 + 1` for `n = 1...100`. The entire stream processing
+ pipeline is expressed without ever mentioning a single value that goes through the pipeline. This style
+ of programming is very expressive and forces one to think in terms of small atomic units and pure
+ functions, the benefits of which are immense.
+ */

--- a/Prelude/ArrayTests.swift
+++ b/Prelude/ArrayTests.swift
@@ -50,7 +50,8 @@ class ArrayTests: XCTestCase {
 
   func testSortedByComparator() {
     let xs = [3, 6, 1, 2]
-    let sorted = xs.sorted(comparator: Comparator { $0 < $1 ? .lt : $0 == $1 ? .eq : .gt })
+    let comparator = Prelude.Comparator<Int> { $0 < $1 ? .lt : $0 == $1 ? .eq : .gt }
+    let sorted = xs.sorted(comparator: comparator)
     XCTAssertEqual([1, 2, 3, 6], sorted)
   }
 }

--- a/Prelude/ComparatorTests.swift
+++ b/Prelude/ComparatorTests.swift
@@ -17,7 +17,7 @@ final class ComparatorTests: XCTestCase {
 
 extension Int {
   static var comparator: Prelude.Comparator<Int> {
-    return Comparator { lhs, rhs in
+    return Prelude.Comparator<Int> { lhs, rhs in
       lhs < rhs ? .lt
       : lhs == rhs ? .eq
       : .gt

--- a/Prelude/Function.swift
+++ b/Prelude/Function.swift
@@ -42,8 +42,29 @@ public func ?|> <A, B> (x: A?, f: (A) -> B) -> B? {
 
  - returns: A function that is the composition of `f` and `g`.
  */
+@available(*, deprecated)
 public func • <A, B, C> (g: @escaping (B) -> C, f: @escaping (A) -> B) -> ((A) -> C) {
   return { x in g(f(x)) }
+}
+
+/**
+ Composes two functions in left-to-right order, i.e. (f >>> g)(x) = g(f(x)
+ - parameter g: A function.
+ - parameter f: A function.
+ - returns: A function that is the composition of `f` and `g`.
+ */
+public func >>> <A, B, C> (f: @escaping (A) -> B, g: @escaping (B) -> C) -> (A) -> C {
+  return { g(f($0)) }
+}
+
+/**
+ Composes two functions in right-to-left order, i.e. (f <<< g)(x) = f(g(x)
+ - parameter g: A function.
+ - parameter f: A function.
+ - returns: A function that is the composition of `f` and `g`.
+ */
+public func <<< <A, B, C> (g: @escaping (B) -> C, f: @escaping (A) -> B) -> (A) -> C {
+  return { g(f($0)) }
 }
 
 /**

--- a/Prelude/FunctionTest.swift
+++ b/Prelude/FunctionTest.swift
@@ -22,12 +22,20 @@ class FunctionTest: XCTestCase {
     XCTAssertNil(nil ?|> square)
   }
 
-  func testCompose() {
+  func testForwardCompose() {
     func square(_ x: Int) -> Int { return x * x }
     func incr(_ x: Int) -> Int { return x + 1 }
 
-    XCTAssertEqual(16, (square • incr)(3))
-    XCTAssertEqual(10, (incr • square)(3))
+    XCTAssertEqual(16, (incr >>> square)(3))
+    XCTAssertEqual(10, (square >>> incr)(3))
+  }
+
+  func testBackwardCompose() {
+    func square(_ x: Int) -> Int { return x * x }
+    func incr(_ x: Int) -> Int { return x + 1 }
+
+    XCTAssertEqual(16, (square <<< incr)(3))
+    XCTAssertEqual(10, (incr <<< square)(3))
   }
 
   func testSemigroupOperation() {

--- a/Prelude/Lens.swift
+++ b/Prelude/Lens.swift
@@ -31,7 +31,7 @@ public struct Lens <Whole, Part> {
    */
   public func compose<Subpart>(_ rhs: Lens<Part, Subpart>) -> Lens<Whole, Subpart> {
     return Lens<Whole, Subpart>(
-      view: rhs.view • self.view,
+      view: self.view >>> rhs.view,
       set: { subPart, whole in
         let part = self.view(whole)
         let newPart = rhs.set(subPart, part)

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -52,3 +52,9 @@ infix operator <>~ : LensSetPrecedence
 
 /// Kleisli lens composition
 infix operator >•>
+
+/// Compose forward operator
+infix operator >>> : FunctionCompositionPrecedence
+
+/// Compose backward operator
+infix operator <<< : FunctionCompositionPrecedence


### PR DESCRIPTION
### What

A lil more prelude clean up to get us on a more modern foundation.

Right now we have `•` for function composition, i.e. `(g • f)(x) = g(f(x)`. The ordering is a lil awkward since you always have to read it backwards, e.g. `isNil • first` means the first entry in a tuple is nil.

The operator `>>>` also does composition, but with a better order: `(f >>> g)(x) = g(f(x))`. Haskell has this operator in addition to composition `.`, and purescript _only_ has this operator, completely eschewing `.`.

We've also introduced `<<<` for when it's more natural to use the other order `(g <<< f)(x) = g(f(x))`.