### PR TITLE
Add .. lens composition operator. Deprecate •.

### DIFF
--- a/Prelude-UIKit/lenses/CGRectLenses.swift
+++ b/Prelude-UIKit/lenses/CGRectLenses.swift
@@ -18,8 +18,8 @@ extension CGRect {
   }
 }
 
-private let _x = CGRect.lens.origin • CGPoint.lens.x
-private let _y = CGRect.lens.origin • CGPoint.lens.y
+private let _x = CGRect.lens.origin..CGPoint.lens.x
+private let _y = CGRect.lens.origin..CGPoint.lens.y
 
 extension Lens where Whole == CGRect, Part == CGPoint {
 
@@ -31,8 +31,8 @@ extension Lens where Whole == CGRect, Part == CGPoint {
   }
 }
 
-private let _width = CGRect.lens.size • CGSize.lens.width
-private let _height = CGRect.lens.size • CGSize.lens.height
+private let _width = CGRect.lens.size..CGSize.lens.width
+private let _height = CGRect.lens.size..CGSize.lens.height
 
 extension Lens where Whole == CGRect, Part == CGSize {
   public var width: Lens<CGRect, CGFloat> {

--- a/Prelude-UIKit/lenses/UIButtonLenses.swift
+++ b/Prelude-UIKit/lenses/UIButtonLenses.swift
@@ -121,10 +121,10 @@ public extension LensHolder where Object: UIButtonProtocol {
 
 extension Lens where Whole: UIButtonProtocol, Part == UILabel {
   public var font: Lens<Whole, UIFont> {
-    return Whole.lens.titleLabel • Part.lens.font
+    return Whole.lens.titleLabel..Part.lens.font
   }
 
   public var textAlignment: Lens<Whole, NSTextAlignment> {
-    return Whole.lens.titleLabel • Part.lens.textAlignment
+    return Whole.lens.titleLabel..Part.lens.textAlignment
   }
 }

--- a/Prelude-UIKit/lenses/UINavigationControllerLenses.swift
+++ b/Prelude-UIKit/lenses/UINavigationControllerLenses.swift
@@ -43,6 +43,6 @@ public extension LensHolder where Object: UINavigationControllerProtocol {
 extension Lens where Whole: UINavigationControllerProtocol, Part == UINavigationBar {
 
   public var barTintColor: Lens<Whole, UIColor?> {
-    return Whole.lens.navigationBar • Part.lens.barTintColor
+    return Whole.lens.navigationBar..Part.lens.barTintColor
   }
 }

--- a/Prelude-UIKit/lenses/UITableViewCellLenses.swift
+++ b/Prelude-UIKit/lenses/UITableViewCellLenses.swift
@@ -26,6 +26,6 @@ public extension LensHolder where Object: UITableViewCellProtocol {
 
 extension Lens where Whole: UITableViewCellProtocol, Part == UIView {
   public var layoutMargins: Lens<Whole, UIEdgeInsets> {
-    return Whole.lens.contentView • Part.lens.layoutMargins
+    return Whole.lens.contentView..Part.lens.layoutMargins
   }
 }

--- a/Prelude-UIKit/lenses/UITableViewControllerLenses.swift
+++ b/Prelude-UIKit/lenses/UITableViewControllerLenses.swift
@@ -20,16 +20,16 @@ public extension LensHolder where Object: UITableViewControllerProtocol {
 extension Lens where Whole: UITableViewControllerProtocol, Part == UITableView {
 
   public var rowHeight: Lens<Whole, CGFloat> {
-    return Whole.lens.tableView • Part.lens.rowHeight
+    return Whole.lens.tableView..Part.lens.rowHeight
   }
 
   public var estimatedRowHeight: Lens<Whole, CGFloat> {
-    return Whole.lens.tableView • Part.lens.estimatedRowHeight
+    return Whole.lens.tableView..Part.lens.estimatedRowHeight
   }
 
   #if os(iOS)
   public var separatorStyle: Lens<Whole, UITableViewCellSeparatorStyle> {
-    return Whole.lens.tableView • Part.lens.separatorStyle
+    return Whole.lens.tableView..Part.lens.separatorStyle
   }
   #endif
 }

--- a/Prelude-UIKit/lenses/UITextViewLenses.swift
+++ b/Prelude-UIKit/lenses/UITextViewLenses.swift
@@ -71,6 +71,6 @@ public extension LensHolder where Object: UITextViewProtocol {
 
 extension Lens where Whole: UITextViewProtocol, Part == NSTextContainer {
   public var lineFragmentPadding: Lens<Whole, CGFloat> {
-    return Whole.lens.textContainer • Part.lens.lineFragmentPadding
+    return Whole.lens.textContainer..Part.lens.lineFragmentPadding
   }
 }

--- a/Prelude-UIKit/lenses/UIViewControllerLenses.swift
+++ b/Prelude-UIKit/lenses/UIViewControllerLenses.swift
@@ -42,14 +42,14 @@ public extension LensHolder where Object: UIViewControllerProtocol {
 
 extension Lens where Whole: UIViewControllerProtocol, Part == UIView {
   public var backgroundColor: Lens<Whole, UIColor> {
-    return Whole.lens.view • Part.lens.backgroundColor
+    return Whole.lens.view..Part.lens.backgroundColor
   }
 
   public var layoutMargins: Lens<Whole, UIEdgeInsets> {
-    return Whole.lens.view • Part.lens.layoutMargins
+    return Whole.lens.view..Part.lens.layoutMargins
   }
 
   public var tintColor: Lens<Whole, UIColor> {
-    return Whole.lens.view • Part.lens.tintColor
+    return Whole.lens.view..Part.lens.tintColor
   }
 }

--- a/Prelude-UIKit/lenses/UIViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIViewLenses.swift
@@ -160,65 +160,65 @@ public extension LensHolder where Object: UIViewProtocol {
 
 public extension Lens where Whole: UIViewProtocol, Part == CGRect {
   public var origin: Lens<Whole, CGPoint> {
-    return Whole.lens.frame • CGRect.lens.origin
+    return Whole.lens.frame..CGRect.lens.origin
   }
   public var size: Lens<Whole, CGSize> {
-    return Whole.lens.frame • CGRect.lens.size
+    return Whole.lens.frame..CGRect.lens.size
   }
 }
 
 public extension Lens where Whole: UIViewProtocol, Part == CGPoint {
   public var x: Lens<Whole, CGFloat> {
-    return Whole.lens.frame.origin • CGPoint.lens.x
+    return Whole.lens.frame.origin..CGPoint.lens.x
   }
   public var y: Lens<Whole, CGFloat> {
-    return Whole.lens.frame.origin • CGPoint.lens.y
+    return Whole.lens.frame.origin..CGPoint.lens.y
   }
 }
 
 public extension Lens where Whole: UIViewProtocol, Part == CGSize {
   public var width: Lens<Whole, CGFloat> {
-    return Whole.lens.frame.size • CGSize.lens.width
+    return Whole.lens.frame.size..CGSize.lens.width
   }
   public var height: Lens<Whole, CGFloat> {
-    return Whole.lens.frame.size • CGSize.lens.height
+    return Whole.lens.frame.size..CGSize.lens.height
   }
 }
 
 public extension Lens where Whole: UIViewProtocol, Part == CALayer {
   public var borderColor: Lens<Whole, CGColor?> {
-    return Whole.lens.layer • Part.lens.borderColor
+    return Whole.lens.layer..Part.lens.borderColor
   }
 
   public var borderWidth: Lens<Whole, CGFloat> {
-    return Whole.lens.layer • Part.lens.borderWidth
+    return Whole.lens.layer..Part.lens.borderWidth
   }
 
   public var cornerRadius: Lens<Whole, CGFloat> {
-    return Whole.lens.layer • Part.lens.cornerRadius
+    return Whole.lens.layer..Part.lens.cornerRadius
   }
 
   public var masksToBounds: Lens<Whole, Bool> {
-    return Whole.lens.layer • Part.lens.masksToBounds
+    return Whole.lens.layer..Part.lens.masksToBounds
   }
 
   public var shadowColor: Lens<Whole, CGColor?> {
-    return Whole.lens.layer • CALayer.lens.shadowColor
+    return Whole.lens.layer..CALayer.lens.shadowColor
   }
 
   public var shadowOffset: Lens<Whole, CGSize> {
-    return Whole.lens.layer • CALayer.lens.shadowOffset
+    return Whole.lens.layer..CALayer.lens.shadowOffset
   }
 
   public var shadowOpacity: Lens<Whole, Float> {
-    return Whole.lens.layer • CALayer.lens.shadowOpacity
+    return Whole.lens.layer..CALayer.lens.shadowOpacity
   }
 
   public var shadowRadius: Lens<Whole, CGFloat> {
-    return Whole.lens.layer • CALayer.lens.shadowRadius
+    return Whole.lens.layer..CALayer.lens.shadowRadius
   }
 
   public var shouldRasterize: Lens<Whole, Bool> {
-    return Whole.lens.layer • CALayer.lens.shouldRasterize
+    return Whole.lens.layer..CALayer.lens.shouldRasterize
   }
 }

--- a/Prelude-UIKit/lenses/UIWebViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIWebViewLenses.swift
@@ -28,11 +28,11 @@ public extension LensHolder where Object: UIWebViewProtocol {
 
 extension Lens where Whole: UIWebViewProtocol, Part == UIScrollView {
   public var delaysContentTouches: Lens<Whole, Bool> {
-    return Whole.lens.scrollView • Part.lens.delaysContentTouches
+    return Whole.lens.scrollView..Part.lens.delaysContentTouches
   }
 
   public var decelerationRate: Lens<Whole, CGFloat> {
-    return Whole.lens.scrollView • Part.lens.decelerationRate
+    return Whole.lens.scrollView..Part.lens.decelerationRate
   }
 }
 #endif

--- a/Prelude-UIKit/lenses/WKWebViewLenses.swift
+++ b/Prelude-UIKit/lenses/WKWebViewLenses.swift
@@ -21,7 +21,7 @@ public extension LensHolder where Object: WKWebViewProtocol {
 
 extension Lens where Whole: WKWebViewProtocol, Part == UIScrollView {
   public var delaysContentTouches: Lens<Whole, Bool> {
-    return Whole.lens.scrollView • Part.lens.delaysContentTouches
+    return Whole.lens.scrollView..Part.lens.delaysContentTouches
   }
 }
 #endif

--- a/Prelude/Lens.swift
+++ b/Prelude/Lens.swift
@@ -83,7 +83,20 @@ public func ^* <Whole, Part> (whole: Whole, lens: Lens<Whole, Part>) -> Part {
 
  - returns: The composed lens.
  */
+@available(*, deprecated)
 public func • <A, B, C> (lhs: Lens<A, B>, rhs: Lens<B, C>) -> Lens<A, C> {
+  return lhs.compose(rhs)
+}
+
+/**
+ Infix operator of `compose`, which composes two lenses.
+
+ - parameter lhs: A lens.
+ - parameter rhs: A lens.
+
+ - returns: The composed lens.
+ */
+public func .. <A, B, C> (lhs: Lens<A, B>, rhs: Lens<B, C>) -> Lens<A, C> {
   return lhs.compose(rhs)
 }
 

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -26,6 +26,9 @@ infix operator ?|> : LeftApplyPrecedence
 /// Composition
 infix operator • : FunctionCompositionPrecedence
 
+/// Lens composition
+infix operator .. : FunctionCompositionPrecedence
+
 /// Semigroup binary operation
 infix operator <> : FunctionCompositionPrecedence
 


### PR DESCRIPTION
### What

If people are down with #74, then y'all will probably also like this.

We currently use `•` for lens composition, e.g. `lensAtoB • lensBtoC`. Notice that ordering is more akin to `>>>` and the opposite of what `•` does on functions. we'd like to clean up this inconsistency. 

I propose to add an operator `..` (also stolen from purescript) for composition that should be analogous to doing dot access `user.location.name`. With that operator we could do `lensAtoB..lensBtoC`. pretty cool~

We could just do `lensAtoB >>> lensBtoC` but it's more verbose and doesnt seem right to me since `>>>` is more about data pipelining.

Thoughts?