### PR TITLE
NonEmpty

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		80904E761D3D461300B897F0 /* NSTextContainerLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80904E751D3D461300B897F0 /* NSTextContainerLenses.swift */; };
 		80904E771D3D48F200B897F0 /* NSTextContainerLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80904E751D3D461300B897F0 /* NSTextContainerLenses.swift */; };
 		8094255B1D1463A00021DEEE /* UITextViewLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8094255A1D1463A00021DEEE /* UITextViewLenses.swift */; };
+		80A0E1A61EB0076A00D69242 /* NonEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A0E1A51EB0076A00D69242 /* NonEmpty.swift */; };
+		80A0E1A71EB0076A00D69242 /* NonEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A0E1A51EB0076A00D69242 /* NonEmpty.swift */; };
+		80A0E1AE1EB02D4A00D69242 /* NonEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A0E1AD1EB02D4A00D69242 /* NonEmptyTests.swift */; };
+		80A0E1AF1EB02D4A00D69242 /* NonEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A0E1AD1EB02D4A00D69242 /* NonEmptyTests.swift */; };
 		9DCD741E1D429AA200B238E5 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCD741D1D429AA200B238E5 /* Ordering.swift */; };
 		9DCD741F1D429AA200B238E5 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCD741D1D429AA200B238E5 /* Ordering.swift */; };
 		9DCD74241D42A42100B238E5 /* Comparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCD74231D42A42100B238E5 /* Comparator.swift */; };
@@ -285,6 +289,8 @@
 		8051B9421D4049FB00F653A7 /* UINavigationControllerLenses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationControllerLenses.swift; sourceTree = "<group>"; };
 		80904E751D3D461300B897F0 /* NSTextContainerLenses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextContainerLenses.swift; sourceTree = "<group>"; };
 		8094255A1D1463A00021DEEE /* UITextViewLenses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextViewLenses.swift; sourceTree = "<group>"; };
+		80A0E1A51EB0076A00D69242 /* NonEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonEmpty.swift; sourceTree = "<group>"; };
+		80A0E1AD1EB02D4A00D69242 /* NonEmptyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonEmptyTests.swift; sourceTree = "<group>"; };
 		9DCD741D1D429AA200B238E5 /* Ordering.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ordering.swift; sourceTree = "<group>"; };
 		9DCD74231D42A42100B238E5 /* Comparator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comparator.swift; sourceTree = "<group>"; };
 		9DCD74261D42A43500B238E5 /* Monoid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Monoid.swift; sourceTree = "<group>"; };
@@ -566,6 +572,8 @@
 				A7CBAA6C1D69E9DE009D7B48 /* LensHolder.swift */,
 				A7C5B8AD1E7F45F7001F9E62 /* LensTests.swift */,
 				9DCD74261D42A43500B238E5 /* Monoid.swift */,
+				80A0E1A51EB0076A00D69242 /* NonEmpty.swift */,
+				80A0E1AD1EB02D4A00D69242 /* NonEmptyTests.swift */,
 				A7EFE1511C28B46900F4CFEB /* NumericType.swift */,
 				A74B3C0C1C9DCD9A00F938C4 /* Operators.swift */,
 				CAC0795E1BBDC00200AFDBF0 /* Optional.swift */,
@@ -1071,6 +1079,7 @@
 				A78323AD1CB9615D000B094C /* Either.swift in Sources */,
 				A711FCDD1CECB53A00659DB4 /* Unpack.swift in Sources */,
 				9DCD741E1D429AA200B238E5 /* Ordering.swift in Sources */,
+				80A0E1A61EB0076A00D69242 /* NonEmpty.swift in Sources */,
 				A7FD08511C81E1DA00332CCB /* VectorType.swift in Sources */,
 				A7FD08521C81E1DA00332CCB /* Comparable.swift in Sources */,
 				A7FD08531C81E1DA00332CCB /* Unit.swift in Sources */,
@@ -1099,6 +1108,7 @@
 				A7C5B8C51E7F45F7001F9E62 /* OrderingTests.swift in Sources */,
 				A7C5B8C71E7F45F7001F9E62 /* StringTests.swift in Sources */,
 				A7C5B8B31E7F45F7001F9E62 /* ArrayTests.swift in Sources */,
+				80A0E1AE1EB02D4A00D69242 /* NonEmptyTests.swift in Sources */,
 				A7C5B8B91E7F45F7001F9E62 /* ComparatorTests.swift in Sources */,
 				A7C5B8C31E7F45F7001F9E62 /* OptionalTests.swift in Sources */,
 				A7C5B8CB1E7F45F7001F9E62 /* UnitTests.swift in Sources */,
@@ -1120,6 +1130,7 @@
 				A78323AE1CB9615D000B094C /* Either.swift in Sources */,
 				A711FCDE1CECB53A00659DB4 /* Unpack.swift in Sources */,
 				9DCD741F1D429AA200B238E5 /* Ordering.swift in Sources */,
+				80A0E1A71EB0076A00D69242 /* NonEmpty.swift in Sources */,
 				A7EFE1541C28B53D00F4CFEB /* VectorType.swift in Sources */,
 				A7F7ADE81C53D27300E39792 /* Comparable.swift in Sources */,
 				A75EFFE21C0E7B8E0002C7D2 /* Unit.swift in Sources */,
@@ -1148,6 +1159,7 @@
 				A7C5B8C61E7F45F7001F9E62 /* OrderingTests.swift in Sources */,
 				A7C5B8C81E7F45F7001F9E62 /* StringTests.swift in Sources */,
 				A7C5B8B41E7F45F7001F9E62 /* ArrayTests.swift in Sources */,
+				80A0E1AF1EB02D4A00D69242 /* NonEmptyTests.swift in Sources */,
 				A7C5B8BA1E7F45F7001F9E62 /* ComparatorTests.swift in Sources */,
 				A7C5B8C41E7F45F7001F9E62 /* OptionalTests.swift in Sources */,
 				A7C5B8CC1E7F45F7001F9E62 /* UnitTests.swift in Sources */,

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		80A0E1A71EB0076A00D69242 /* NonEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A0E1A51EB0076A00D69242 /* NonEmpty.swift */; };
 		80A0E1AE1EB02D4A00D69242 /* NonEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A0E1AD1EB02D4A00D69242 /* NonEmptyTests.swift */; };
 		80A0E1AF1EB02D4A00D69242 /* NonEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A0E1AD1EB02D4A00D69242 /* NonEmptyTests.swift */; };
+		80A9DF3B1EB1A9AE00CEF5CC /* Set.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A9DF3A1EB1A9AE00CEF5CC /* Set.swift */; };
+		80A9DF3C1EB1A9AE00CEF5CC /* Set.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A9DF3A1EB1A9AE00CEF5CC /* Set.swift */; };
 		9DCD741E1D429AA200B238E5 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCD741D1D429AA200B238E5 /* Ordering.swift */; };
 		9DCD741F1D429AA200B238E5 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCD741D1D429AA200B238E5 /* Ordering.swift */; };
 		9DCD74241D42A42100B238E5 /* Comparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCD74231D42A42100B238E5 /* Comparator.swift */; };
@@ -291,6 +293,7 @@
 		8094255A1D1463A00021DEEE /* UITextViewLenses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextViewLenses.swift; sourceTree = "<group>"; };
 		80A0E1A51EB0076A00D69242 /* NonEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonEmpty.swift; sourceTree = "<group>"; };
 		80A0E1AD1EB02D4A00D69242 /* NonEmptyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonEmptyTests.swift; sourceTree = "<group>"; };
+		80A9DF3A1EB1A9AE00CEF5CC /* Set.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Set.swift; sourceTree = "<group>"; };
 		9DCD741D1D429AA200B238E5 /* Ordering.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ordering.swift; sourceTree = "<group>"; };
 		9DCD74231D42A42100B238E5 /* Comparator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comparator.swift; sourceTree = "<group>"; };
 		9DCD74261D42A43500B238E5 /* Monoid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Monoid.swift; sourceTree = "<group>"; };
@@ -581,6 +584,7 @@
 				9DCD741D1D429AA200B238E5 /* Ordering.swift */,
 				A7C5B8AF1E7F45F7001F9E62 /* OrderingTests.swift */,
 				A7AD8BBF1C9DCBC200016122 /* Semigroup.swift */,
+				80A9DF3A1EB1A9AE00CEF5CC /* Set.swift */,
 				A7DBFCF21C5EB661002150A1 /* SomeError.swift */,
 				A74B3C091C9DCC7600F938C4 /* String.swift */,
 				A7C5B8B01E7F45F7001F9E62 /* StringTests.swift */,
@@ -1079,6 +1083,7 @@
 				A78323AD1CB9615D000B094C /* Either.swift in Sources */,
 				A711FCDD1CECB53A00659DB4 /* Unpack.swift in Sources */,
 				9DCD741E1D429AA200B238E5 /* Ordering.swift in Sources */,
+				80A9DF3B1EB1A9AE00CEF5CC /* Set.swift in Sources */,
 				80A0E1A61EB0076A00D69242 /* NonEmpty.swift in Sources */,
 				A7FD08511C81E1DA00332CCB /* VectorType.swift in Sources */,
 				A7FD08521C81E1DA00332CCB /* Comparable.swift in Sources */,
@@ -1130,6 +1135,7 @@
 				A78323AE1CB9615D000B094C /* Either.swift in Sources */,
 				A711FCDE1CECB53A00659DB4 /* Unpack.swift in Sources */,
 				9DCD741F1D429AA200B238E5 /* Ordering.swift in Sources */,
+				80A9DF3C1EB1A9AE00CEF5CC /* Set.swift in Sources */,
 				80A0E1A71EB0076A00D69242 /* NonEmpty.swift in Sources */,
 				A7EFE1541C28B53D00F4CFEB /* VectorType.swift in Sources */,
 				A7F7ADE81C53D27300E39792 /* Comparable.swift in Sources */,

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -20,6 +20,12 @@ extension NonEmpty {
   }
 }
 
+extension NonEmpty where Collection: RandomAccessCollection {
+  public var last: Element {
+    return tail.last ?? head
+  }
+}
+
 extension Array {
   public init<C: Collection>(_ nonEmpty: NonEmpty<C>) where C.Iterator.Element == Element {
     self = [nonEmpty.head] + Array(nonEmpty.tail)

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -31,7 +31,7 @@ public struct NonEmptyArray<Element>: NonEmpty {
 
 extension NonEmptyArray {
   public init(_ head: Element, _ tail: Element...) {
-    self.init(head: self.head, tail: self.tail)
+    self.init(head: head, tail: tail)
   }
 }
 

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -33,12 +33,6 @@ extension NonEmptyArray {
   }
 }
 
-extension NonEmptyArray: Semigroup {
-  public func op(_ other: NonEmptyArray) -> NonEmptyArray {
-    return NonEmptyArray(head: self.head, tail: self.tail <> [other.head] <> other.tail)
-  }
-}
-
 public func == <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> Bool where T: Equatable {
   return lhs.head == rhs.head && lhs.tail == rhs.tail
 }
@@ -57,6 +51,12 @@ extension Array {
   }
 }
 
+extension NonEmptyArray: Semigroup {
+  public func op(_ other: NonEmptyArray) -> NonEmptyArray {
+    return self.head +| (self.tail <> [other.head] <> other.tail)
+  }
+}
+
 // MARK: Set
 
 public struct NonEmptySet<Element>: NonEmpty where Element: Hashable {
@@ -67,14 +67,6 @@ public struct NonEmptySet<Element>: NonEmpty where Element: Hashable {
 extension NonEmptySet {
   public init(_ head: Element, _ tail: Element...) {
     self.init(head: head, tail: Set(tail).subtracting([head]))
-  }
-}
-
-extension NonEmptySet: Semigroup {
-  public func op(_ other: NonEmptySet) -> NonEmptySet {
-    return NonEmptySet(
-      head: self.head, tail: (self.tail <> [other.head] <> other.tail).subtracting([self.head])
-    )
   }
 }
 
@@ -93,5 +85,11 @@ public func +| <T>(head: T, tail: Set<T>) -> NonEmptySet<T> {
 extension Array where Element: Hashable {
   public init(_ nonEmpty: NonEmptySet<Element>) {
     self = [nonEmpty.head] + Array(nonEmpty.tail)
+  }
+}
+
+extension NonEmptySet: Semigroup {
+  public func op(_ other: NonEmptySet) -> NonEmptySet {
+    return self.head +| (self.tail <> [other.head] <> other.tail)
   }
 }

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -20,8 +20,6 @@ extension NonEmpty where Collection: RandomAccessCollection {
   }
 }
 
-infix operator >|: AdditionPrecedence
-
 // MARK: Array
 
 public struct NonEmptyArray<Element>: NonEmpty {
@@ -49,7 +47,7 @@ public func != <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> Bool where T
   return !(lhs == rhs)
 }
 
-public func >| <T>(head: T, tail: [T]) -> NonEmptyArray<T> {
+public func +| <T>(head: T, tail: [T]) -> NonEmptyArray<T> {
   return NonEmptyArray<T>(head: head, tail: tail)
 }
 
@@ -88,7 +86,7 @@ public func != <T>(lhs: NonEmptySet<T>, rhs: NonEmptySet<T>) -> Bool {
   return lhs.head != rhs.head || lhs.tail != rhs.tail
 }
 
-public func >| <T>(head: T, tail: Set<T>) -> NonEmptySet<T> {
+public func +| <T>(head: T, tail: Set<T>) -> NonEmptySet<T> {
   return NonEmptySet<T>(head: head, tail: tail.subtracting([head]))
 }
 

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -1,4 +1,4 @@
-public struct NonEmpty<Collection: Swift.Collection> {
+public struct NonEmpty<Collection> where Collection: Swift.Collection {
   public typealias Element = Collection.Iterator.Element
   public let head: Element
   public let tail: Collection
@@ -67,7 +67,7 @@ public func <> <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> NonEmptyArra
 
 // MARK: Set
 
-public typealias NonEmptySet<Element: Hashable> = NonEmpty<Set<Element>>
+public typealias NonEmptySet<Element> = NonEmpty<Set<Element>> where Element: Hashable
 
 public func == <T>(lhs: NonEmptySet<T>, rhs: NonEmptySet<T>) -> Bool {
   return lhs.head == rhs.head && lhs.tail == rhs.tail

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -34,7 +34,7 @@ extension Array {
 
 // MARK: Array
 
-public typealias NonEmptyArray<Element> = NonEmpty<Array<Element>>
+public typealias NonEmptyArray<Element> = NonEmpty<[Element]>
 
 public func == <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> Bool where T: Equatable {
   return lhs.head == rhs.head && lhs.tail == rhs.tail

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -1,0 +1,90 @@
+public struct NonEmpty<Collection: Swift.Collection> {
+  public typealias Element = Collection.Iterator.Element
+  public let head: Collection.Iterator.Element
+  public let tail: Collection
+}
+
+infix operator >|: AdditionPrecedence
+
+public func >| <C: Collection>(head: C.Iterator.Element, tail: C) -> NonEmpty<C> {
+  return NonEmpty<C>(head: head, tail: tail)
+}
+
+extension NonEmpty {
+  public var count: Collection.IndexDistance {
+    return tail.count.advanced(by: 1)
+  }
+
+  public var first: Element {
+    return head
+  }
+}
+
+extension Array {
+  public init<C: Collection>(_ nonEmpty: NonEmpty<C>) where C.Iterator.Element == Element {
+    self = [nonEmpty.head] + Array(nonEmpty.tail)
+  }
+}
+
+// MARK: Array
+
+public typealias NonEmptyArray<Element> = NonEmpty<Array<Element>>
+
+public func == <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> Bool where T: Equatable {
+  return lhs.head == rhs.head && lhs.tail == rhs.tail
+}
+
+public func != <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> Bool where T: Equatable {
+  return lhs.head != rhs.head && lhs.tail != rhs.tail
+}
+
+public protocol ArrayType {
+  associatedtype Iterator: IteratorProtocol
+  init(array: [Iterator.Element])
+}
+
+extension Array: ArrayType {
+  public init(array: Array) {
+    self = array
+  }
+}
+
+extension NonEmpty where Collection: ArrayType {
+  public init(_ head: Element, _ tail: Element...) {
+    self.init(head: head, tail: Collection(array: tail))
+  }
+}
+
+// MARK: Set
+
+public typealias NonEmptySet<Element: Hashable> = NonEmpty<Set<Element>>
+
+public func == <T>(lhs: NonEmptySet<T>, rhs: NonEmptySet<T>) -> Bool {
+  return lhs.head == rhs.head && lhs.tail == rhs.tail
+}
+
+public func != <T>(lhs: NonEmptySet<T>, rhs: NonEmptySet<T>) -> Bool {
+  return lhs.head != rhs.head || lhs.tail != rhs.tail
+}
+
+public protocol SetType {
+  associatedtype Iterator: IteratorProtocol
+  init(array: [Iterator.Element])
+  func subtracting<S>(_ other: S) -> Self where S : Sequence, S.Iterator.Element == Iterator.Element
+}
+
+extension Set: SetType {
+  public init(array: [Element]) {
+    self = Set(array)
+  }
+}
+
+public func >| <T>(head: T, tail: Set<T>) -> NonEmptySet<T> {
+  return NonEmpty<Set<T>>(head: head, tail: tail.subtracting([head]))
+}
+
+extension NonEmpty where Collection: SetType, Collection.Iterator.Element: Hashable {
+  public init(_ head: Element, _ tail: Element...) {
+    self.init(head: head, tail: Collection(array: tail).subtracting([head]))
+  }
+}

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -6,7 +6,7 @@ public struct NonEmpty<Collection: Swift.Collection> {
 
 infix operator >|: AdditionPrecedence
 
-public func >| <C: Collection>(head: C.Iterator.Element, tail: C) -> NonEmpty<C> {
+public func >| <C>(head: C.Iterator.Element, tail: C) -> NonEmpty<C> where C: Collection {
   return NonEmpty<C>(head: head, tail: tail)
 }
 
@@ -27,7 +27,7 @@ extension NonEmpty where Collection: RandomAccessCollection {
 }
 
 extension Array {
-  public init<C: Collection>(_ nonEmpty: NonEmpty<C>) where C.Iterator.Element == Element {
+  public init<C>(_ nonEmpty: NonEmpty<C>) where C: Collection, C.Iterator.Element == Element {
     self = [nonEmpty.head] + Array(nonEmpty.tail)
   }
 }
@@ -80,7 +80,7 @@ public func != <T>(lhs: NonEmptySet<T>, rhs: NonEmptySet<T>) -> Bool {
 public protocol SetType {
   associatedtype Iterator: IteratorProtocol
   init(array: [Iterator.Element])
-  func subtracting<S>(_ other: S) -> Self where S : Sequence, S.Iterator.Element == Iterator.Element
+  func subtracting<S>(_ other: S) -> Self where S: Sequence, S.Iterator.Element == Iterator.Element
 }
 
 extension Set: SetType {
@@ -90,7 +90,7 @@ extension Set: SetType {
 }
 
 public func >| <T>(head: T, tail: Set<T>) -> NonEmptySet<T> {
-  return NonEmpty<Set<T>>(head: head, tail: tail.subtracting([head]))
+  return NonEmptySet<T>(head: head, tail: tail.subtracting([head]))
 }
 
 extension NonEmpty where Collection: SetType, Collection.Iterator.Element: Hashable {

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -1,6 +1,6 @@
 public struct NonEmpty<Collection: Swift.Collection> {
   public typealias Element = Collection.Iterator.Element
-  public let head: Collection.Iterator.Element
+  public let head: Element
   public let tail: Collection
 }
 

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -6,17 +6,17 @@ public protocol NonEmpty {
 
 extension NonEmpty {
   public var count: Collection.IndexDistance {
-    return tail.count.advanced(by: 1)
+    return self.tail.count.advanced(by: 1)
   }
 
   public var first: Collection.Iterator.Element {
-    return head
+    return self.head
   }
 }
 
 extension NonEmpty where Collection: RandomAccessCollection {
   public var last: Collection.Iterator.Element {
-    return tail.last ?? head
+    return self.tail.last ?? self.head
   }
 }
 
@@ -31,7 +31,7 @@ public struct NonEmptyArray<Element>: NonEmpty {
 
 extension NonEmptyArray {
   public init(_ head: Element, _ tail: Element...) {
-    self.init(head: head, tail: tail)
+    self.init(head: self.head, tail: self.tail)
   }
 }
 
@@ -46,7 +46,7 @@ public func == <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> Bool where T
 }
 
 public func != <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> Bool where T: Equatable {
-  return lhs.head != rhs.head && lhs.tail != rhs.tail
+  return !(lhs == rhs)
 }
 
 public func >| <T>(head: T, tail: [T]) -> NonEmptyArray<T> {

--- a/Prelude/NonEmpty.swift
+++ b/Prelude/NonEmpty.swift
@@ -61,6 +61,10 @@ extension NonEmpty where Collection: ArrayType {
   }
 }
 
+public func <> <T>(lhs: NonEmptyArray<T>, rhs: NonEmptyArray<T>) -> NonEmptyArray<T> {
+  return lhs.head >| (lhs.tail <> [rhs.head] <> rhs.tail)
+}
+
 // MARK: Set
 
 public typealias NonEmptySet<Element: Hashable> = NonEmpty<Set<Element>>

--- a/Prelude/NonEmptyTests.swift
+++ b/Prelude/NonEmptyTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import Prelude
+
+final class NonEmptyTests: XCTestCase {
+
+  func testArrayConversion() {
+    XCTAssert([1, 2, 3] == Array(NonEmptyArray(1, 2, 3)))
+    XCTAssert([1, 2, 3] == Array(NonEmptySet(1, 1, 2, 3)).sorted())
+  }
+
+  func testCount() {
+    XCTAssertEqual(3, NonEmptyArray(1, 2, 3).count)
+    XCTAssertEqual(3, NonEmptySet(1, 1, 2, 3).count)
+  }
+
+  func testFirst() {
+    XCTAssertEqual(1, NonEmptyArray(1, 2, 3).first)
+    XCTAssertEqual(1, NonEmptySet(1, 1, 2, 3).first)
+  }
+
+  func testEquality() {
+    XCTAssert(NonEmptyArray(1, 2, 3) == NonEmptyArray(1, 2, 3))
+    XCTAssert(NonEmptyArray(1, 2, 3) != NonEmptyArray(2, 3, 4))
+    XCTAssert(NonEmptySet(1, 1, 2, 3) == NonEmptySet(1, 2, 3))
+    XCTAssert(NonEmptySet(1, 2, 3) != NonEmptySet(1, 2, 3, 4))
+
+    XCTAssert(1 >| [2, 3] == NonEmptyArray(1, 2, 3))
+    XCTAssert(1 >| [2, 3] != NonEmptyArray(2, 3, 4))
+    XCTAssert(1 >| [1, 2, 3] == NonEmptySet(1, 2, 3))
+    XCTAssert(1 >| [2, 3] != NonEmptySet(1, 2, 3, 4))
+  }
+}

--- a/Prelude/NonEmptyTests.swift
+++ b/Prelude/NonEmptyTests.swift
@@ -19,6 +19,7 @@ final class NonEmptyTests: XCTestCase {
   }
 
   func testLast() {
+    XCTAssertEqual(1, NonEmptyArray(1).last)
     XCTAssertEqual(3, NonEmptyArray(1, 2, 3).last)
   }
 
@@ -35,6 +36,6 @@ final class NonEmptyTests: XCTestCase {
   }
 
   func testArraySemigroup() {
-    XCTAssert(NonEmptyArray(1, 2, 3) == (NonEmptyArray(1) <> NonEmptyArray(2, 3)))
+    XCTAssert(NonEmptyArray(1, 2, 3, 4) == (NonEmptyArray(1, 2) <> NonEmptyArray(3, 4)))
   }
 }

--- a/Prelude/NonEmptyTests.swift
+++ b/Prelude/NonEmptyTests.swift
@@ -33,4 +33,8 @@ final class NonEmptyTests: XCTestCase {
     XCTAssert(1 >| [1, 2, 3] == NonEmptySet(1, 2, 3))
     XCTAssert(1 >| [2, 3] != NonEmptySet(1, 2, 3, 4))
   }
+
+  func testArraySemigroup() {
+    XCTAssert(NonEmptyArray(1, 2, 3) == (NonEmptyArray(1) <> NonEmptyArray(2, 3)))
+  }
 }

--- a/Prelude/NonEmptyTests.swift
+++ b/Prelude/NonEmptyTests.swift
@@ -26,8 +26,10 @@ final class NonEmptyTests: XCTestCase {
   func testEquality() {
     XCTAssert(NonEmptyArray(1, 2, 3) == NonEmptyArray(1, 2, 3))
     XCTAssert(NonEmptyArray(1, 2, 3) != NonEmptyArray(2, 3, 4))
+    XCTAssert(NonEmptyArray(1, 2) != NonEmptyArray(2, 2))
     XCTAssert(NonEmptySet(1, 1, 2, 3) == NonEmptySet(1, 2, 3))
     XCTAssert(NonEmptySet(1, 2, 3) != NonEmptySet(1, 2, 3, 4))
+    XCTAssert(NonEmptySet(1, 2) != NonEmptySet(2, 2))
 
     XCTAssert(1 >| [2, 3] == NonEmptyArray(1, 2, 3))
     XCTAssert(1 >| [2, 3] != NonEmptyArray(2, 3, 4))

--- a/Prelude/NonEmptyTests.swift
+++ b/Prelude/NonEmptyTests.swift
@@ -31,10 +31,10 @@ final class NonEmptyTests: XCTestCase {
     XCTAssert(NonEmptySet(1, 2, 3) != NonEmptySet(1, 2, 3, 4))
     XCTAssert(NonEmptySet(1, 2) != NonEmptySet(2, 2))
 
-    XCTAssert(1 >| [2, 3] == NonEmptyArray(1, 2, 3))
-    XCTAssert(1 >| [2, 3] != NonEmptyArray(2, 3, 4))
-    XCTAssert(1 >| [1, 2, 3] == NonEmptySet(1, 2, 3))
-    XCTAssert(1 >| [2, 3] != NonEmptySet(1, 2, 3, 4))
+    XCTAssert(1 +| [2, 3] == NonEmptyArray(1, 2, 3))
+    XCTAssert(1 +| [2, 3] != NonEmptyArray(2, 3, 4))
+    XCTAssert(1 +| [1, 2, 3] == NonEmptySet(1, 2, 3))
+    XCTAssert(1 +| [2, 3] != NonEmptySet(1, 2, 3, 4))
   }
 
   func testArraySemigroup() {

--- a/Prelude/NonEmptyTests.swift
+++ b/Prelude/NonEmptyTests.swift
@@ -18,6 +18,10 @@ final class NonEmptyTests: XCTestCase {
     XCTAssertEqual(1, NonEmptySet(1, 1, 2, 3).first)
   }
 
+  func testLast() {
+    XCTAssertEqual(3, NonEmptyArray(1, 2, 3).last)
+  }
+
   func testEquality() {
     XCTAssert(NonEmptyArray(1, 2, 3) == NonEmptyArray(1, 2, 3))
     XCTAssert(NonEmptyArray(1, 2, 3) != NonEmptyArray(2, 3, 4))

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -61,3 +61,6 @@ infix operator >>> : FunctionCompositionPrecedence
 
 /// Compose backward operator
 infix operator <<< : FunctionCompositionPrecedence
+
+/// Cons of an element with a non-empty collection.
+infix operator +|: AdditionPrecedence

--- a/Prelude/Set.swift
+++ b/Prelude/Set.swift
@@ -1,0 +1,5 @@
+extension Set: Semigroup {
+  public func op(_ other: Set) -> Set {
+    return self.union(other)
+  }
+}


### PR DESCRIPTION
From some recent discussion (_e.g._, making sure our GraphQL queries specify at least one field), here's an attempt at a flexible `NonEmpty`!

``` swift
let alwaysFilled = NonEmptyArray(1, 2, 3) // NonEmpty<Array<Int>>
let alsoAlwaysFilled = 1 >| [2, 3]

let filledSet = NonEmptySet(1, 2, 3) // NonEmpty<Set<Int>>
```

Any collection should work. The API is pretty light for now. Just:

- A way to specify collections inputs that require at least one value (using the type, `NonEmpty`)
- A way to convert back to an array (`Array(nonEmpty)`)
- A coupla "nice" type aliases and initializers (`NonEmptyArray(1, 2, 3)`, `NonEmptySet(1, 2, 3)`).
- An alternative operator initializer (`1 >| [2, 3]`)
- `count`, and non-optional `first` and `last`.
- `Array`-specific semigroup stuff (could add `Set`, too, but can't partially conform the type itself to `Semigroup` in Swift yet)

I'm open to suggestions on something other than `>|`! Prior art is `:|`, which looks a little like cons, _e.g._, `x : xs`, `1 : 2 : 3 : []`, but we don't really have anything like that in Swift or our Prelude, so we could use something that looks a bit more like we're injecting an always into a something.