### PR TITLE
Better operator precedence

### DIFF
--- a/Prelude/LensTests.swift
+++ b/Prelude/LensTests.swift
@@ -23,7 +23,7 @@ final class LensTests: XCTestCase {
   }
 
   func testLensSetAndCompositionOperatorPrecedence() {
-    XCTAssertEqual(4, ((User._location..Location._id) .~ 4)(user).location.id)
+    XCTAssertEqual(4, (User._location..Location._id .~ 4)(user).location.id)
   }
 
   func testLensViewOperator() {
@@ -59,19 +59,19 @@ final class LensTests: XCTestCase {
     XCTAssertEqual(User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando"),
       user
         |> User._id %~ add(10)
-        |> (User._location..Location._id) %~ square
-        |> (User._location..Location._id) %~ add(8)
-        |> (User._location..Location._city..City._id) .~ 13
+        |> User._location..Location._id %~ square
+        |> User._location..Location._id %~ add(8)
+        |> User._location..Location._city..City._id .~ 13
         |> User._name .~ "brando"
     )
 
     XCTAssertEqual(13,
       user
         |> User._id %~ add(10)
-        |> (User._location..Location._id) %~ square
-        |> (User._location..Location._id) %~ add(8)
-        |> (User._location..Location._city..City._id) .~ 13
-        ^* (User._location..Location._city..City._id)
+        |> User._location..Location._id %~ square
+        |> User._location..Location._id %~ add(8)
+        |> User._location..Location._city..City._id .~ 13
+        ^* User._location..Location._city..City._id
     )
   }
 

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -6,12 +6,12 @@ precedencegroup LeftApplyPrecedence {
 
 precedencegroup FunctionCompositionPrecedence {
   associativity: right
-  higherThan: LeftApplyPrecedence
+  higherThan: LensSetPrecedence
 }
 
 precedencegroup LensSetPrecedence {
   associativity: left
-  higherThan: FunctionCompositionPrecedence
+  higherThan: LeftApplyPrecedence
 }
 
 /// Pipe forward function application.


### PR DESCRIPTION
Just realized that `..` precedence should be higher precedence than `.~`/`%~` so that you could do stuff like `model |> lensA..lensB .~ value` without parens.