### PR TITLE
Operator precedence fix

### DIFF
--- a/Prelude/LensTests.swift
+++ b/Prelude/LensTests.swift
@@ -56,13 +56,28 @@ final class LensTests: XCTestCase {
   }
 
   func testOperatorPrecedences() {
-    XCTAssertEqual(User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando"),
+    let user = User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando")
+
+    XCTAssertEqual(
+      "brando",
       user
         |> User._id %~ add(10)
         |> User._location..Location._id %~ square
         |> User._location..Location._id %~ add(8)
         |> User._location..Location._city..City._id .~ 13
         |> User._name .~ "brando"
+    )
+
+    XCTAssertEqual(
+      "brando",
+      user
+        |> (
+          User._id %~ add(10)
+            <> User._location..Location._id %~ square
+            <> User._location..Location._id %~ add(8)
+            <> User._location..Location._city..City._id .~ 13
+            <> User._name .~ "brando"
+      )
     )
 
     XCTAssertEqual(13,

--- a/Prelude/LensTests.swift
+++ b/Prelude/LensTests.swift
@@ -56,10 +56,8 @@ final class LensTests: XCTestCase {
   }
 
   func testOperatorPrecedences() {
-    let user = User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando")
-
     XCTAssertEqual(
-      "brando",
+      User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando"),
       user
         |> User._id %~ add(10)
         |> User._location..Location._id %~ square
@@ -69,7 +67,7 @@ final class LensTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      "brando",
+      User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando"),
       user
         |> (
           User._id %~ add(10)

--- a/Prelude/LensTests.swift
+++ b/Prelude/LensTests.swift
@@ -69,13 +69,11 @@ final class LensTests: XCTestCase {
     XCTAssertEqual(
       User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando"),
       user
-        |> (
-          User._id %~ add(10)
-            <> User._location..Location._id %~ square
-            <> User._location..Location._id %~ add(8)
-            <> User._location..Location._city..City._id .~ 13
-            <> User._name .~ "brando"
-      )
+        |> User._id %~ add(10)
+        <> User._location..Location._id %~ square
+        <> User._location..Location._id %~ add(8)
+        <> User._location..Location._city..City._id .~ 13
+        <> User._name .~ "brando"
     )
 
     XCTAssertEqual(13,

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -19,8 +19,6 @@ precedencegroup LensSetPrecedence {
   higherThan: FunctionCompositionPrecedence
 }
 
-//  `..` > `.~` > `<>` > `|>`
-
 /// Pipe forward function application.
 infix operator |> : LeftApplyPrecedence
 

--- a/Prelude/Operators.swift
+++ b/Prelude/Operators.swift
@@ -6,13 +6,20 @@ precedencegroup LeftApplyPrecedence {
 
 precedencegroup FunctionCompositionPrecedence {
   associativity: right
+  higherThan: LeftApplyPrecedence
+}
+
+precedencegroup LensCompositionPrecedence {
+  associativity: right
   higherThan: LensSetPrecedence
 }
 
 precedencegroup LensSetPrecedence {
   associativity: left
-  higherThan: LeftApplyPrecedence
+  higherThan: FunctionCompositionPrecedence
 }
+
+//  `..` > `.~` > `<>` > `|>`
 
 /// Pipe forward function application.
 infix operator |> : LeftApplyPrecedence
@@ -27,7 +34,7 @@ infix operator ?|> : LeftApplyPrecedence
 infix operator • : FunctionCompositionPrecedence
 
 /// Lens composition
-infix operator .. : FunctionCompositionPrecedence
+infix operator .. : LensCompositionPrecedence
 
 /// Semigroup binary operation
 infix operator <> : FunctionCompositionPrecedence


### PR DESCRIPTION
@dimsmol [caught an error](https://github.com/kickstarter/Kickstarter-Prelude/pull/77#issuecomment-298061386) in our precedence order and so this fixes it! Basically the order is:

```swift
highest
-----------
..
.~, %~
<>
|>
-----------
lowest
```

we hadn't see this yet cause I hadn't yet updated the main app to use the newest prelude.

thanks @dimsmol!
