### PR TITLE
Add keypath lens function and operators

### DIFF
--- a/Prelude-UIKit/lenses/CALayerLenses.swift
+++ b/Prelude-UIKit/lenses/CALayerLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/NSMutableParagraphStyleLenses.swift
+++ b/Prelude-UIKit/lenses/NSMutableParagraphStyleLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UIAccessibilityLenses.swift
+++ b/Prelude-UIKit/lenses/UIAccessibilityLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UIBarButtonItemLenses.swift
+++ b/Prelude-UIKit/lenses/UIBarButtonItemLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UIBarItemLenses.swift
+++ b/Prelude-UIKit/lenses/UIBarItemLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UIButtonLenses.swift
+++ b/Prelude-UIKit/lenses/UIButtonLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UIControlLenses.swift
+++ b/Prelude-UIKit/lenses/UIControlLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UIScrollViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIScrollViewLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UIStackViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIStackViewLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UITabBarItemLenses.swift
+++ b/Prelude-UIKit/lenses/UITabBarItemLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/UITabBarLenses.swift
+++ b/Prelude-UIKit/lenses/UITabBarLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import UIKit
 

--- a/Prelude-UIKit/lenses/WKWebViewLenses.swift
+++ b/Prelude-UIKit/lenses/WKWebViewLenses.swift
@@ -1,5 +1,4 @@
 #if os(iOS)
-// swiftlint:disable type_name
 import Prelude
 import WebKit
 

--- a/Prelude/Lens.swift
+++ b/Prelude/Lens.swift
@@ -156,3 +156,71 @@ public func %~~ <Whole, Part> (lens: Lens<Whole, Part>,
 public func <>~ <Whole, Part: Semigroup> (lens: Lens<Whole, Part>, a: Part) -> ((Whole) -> Whole) {
   return lens.over(<>a)
 }
+
+// MARK: - KeyPath lenses
+
+public func lens<Whole, Part>(_ keyPath: WritableKeyPath<Whole, Part>) -> Lens<Whole, Part> {
+  return Lens<Whole, Part>(
+    view: { $0[keyPath: keyPath] },
+    set: { part, whole in
+      var copy = whole
+      copy[keyPath: keyPath] = part
+      return copy
+  }
+  )
+}
+
+/**
+ Infix operator of the `set` function.
+
+ - parameter keyPath: A key path.
+ - parameter part:    A part.
+
+ - returns: A function that transforms a whole into a new whole with a part replaced.
+ */
+public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, part: Part) -> ((Whole) -> Whole) {
+  return lens(keyPath) .~ part
+}
+
+
+/**
+ Infix operator of the `over` function.
+
+ - parameter keyPath: A key path.
+ - parameter f:       A function for transforming a part of a whole.
+
+ - returns: A function that transforms a whole into a new whole with its part transformed by `f`.
+ */
+public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, f: @escaping (Part) -> Part)
+  -> ((Whole) -> Whole) {
+
+    return lens(keyPath) %~ f
+}
+
+/**
+ Variation of the infix operator %~.
+
+ - parameter keyPath: A key path.
+ - parameter f:       A function for transforming a part and whole into a new part.
+
+ - returns: A function that transforms a whole into a new whole with its part transformed by `f`.
+ */
+public func %~~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>,
+                               f: @escaping (Part, Whole) -> Part) -> ((Whole) -> Whole) {
+
+  return lens(keyPath) %~~ f
+}
+
+/**
+ Infix operator to transform a part of a whole with a semigroup operation.
+
+ - parameter keyPath: A key path whose part is a semigroup.
+ - parameter a:       A part value that is concatenated to the part of a whole.
+
+ - returns: A function that transform a whole into a new whole with its part concatenated to `a`.
+ */
+public func <>~ <Whole, Part: Semigroup> (keyPath: WritableKeyPath<Whole, Part>, a: Part)
+  -> ((Whole) -> Whole) {
+
+    return lens(keyPath) <>~ a
+}

--- a/Prelude/Lens.swift
+++ b/Prelude/Lens.swift
@@ -182,7 +182,6 @@ public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, part: Part)
   return lens(keyPath) .~ part
 }
 
-
 /**
  Infix operator of the `over` function.
 

--- a/Prelude/LensTests.swift
+++ b/Prelude/LensTests.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import Prelude
 
 private let square: (Int) -> Int = { $0 * $0 }
-private let add: (Int) -> (Int) -> Int = { lhs in { lhs + $0 } }
-private let incr: (Int) -> Int = add(1)
+private let plus: (Int) -> (Int) -> Int = { lhs in { lhs + $0 } }
+private let incr: (Int) -> Int = plus(1)
 
 final class LensTests: XCTestCase {
   private let user = User(id: 1, location: Location(id: 2, city: City(id: 3)), name: "blob")
@@ -59,9 +59,9 @@ final class LensTests: XCTestCase {
     XCTAssertEqual(
       User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando"),
       user
-        |> User._id %~ add(10)
+        |> User._id %~ plus(10)
         |> User._location..Location._id %~ square
-        |> User._location..Location._id %~ add(8)
+        |> User._location..Location._id %~ plus(8)
         |> User._location..Location._city..City._id .~ 13
         |> User._name .~ "brando"
     )
@@ -69,18 +69,18 @@ final class LensTests: XCTestCase {
     XCTAssertEqual(
       User(id: 11, location: Location(id: 12, city: City(id: 13)), name: "brando"),
       user
-        |> User._id %~ add(10)
+        |> User._id %~ plus(10)
         <> User._location..Location._id %~ square
-        <> User._location..Location._id %~ add(8)
+        <> User._location..Location._id %~ plus(8)
         <> User._location..Location._city..City._id .~ 13
         <> User._name .~ "brando"
     )
 
     XCTAssertEqual(13,
       user
-        |> User._id %~ add(10)
+        |> User._id %~ plus(10)
         |> User._location..Location._id %~ square
-        |> User._location..Location._id %~ add(8)
+        |> User._location..Location._id %~ plus(8)
         |> User._location..Location._city..City._id .~ 13
         ^* User._location..Location._city..City._id
     )

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 8.3
+    version: 9.0
 dependencies:
   pre:
     - brew update || brew update
@@ -22,12 +22,12 @@ test:
     - set -o pipefail &&
       swiftlint lint --strict --reporter json |
       tee $CIRCLE_ARTIFACTS/swiftlint-report.json
-    - bin/test iOS 9.3
-    - bin/test iOS 10.2
-    - bin/test UIKit-iOS 9.3
-    - bin/test UIKit-iOS 10.2
-    - bin/test tvOS 10.0
-    - bin/test UIKit-tvOS 10.0
+    - bin/test iOS 11.0
+    - bin/test iOS 10.3.1
+    - bin/test UIKit-iOS 11.0
+    - bin/test UIKit-iOS 10.3.1
+    - bin/test tvOS 10.2
+    - bin/test UIKit-tvOS 10.2
 experimental:
   notify:
     branches:

--- a/circle.yml
+++ b/circle.yml
@@ -26,8 +26,6 @@ test:
     - bin/test iOS 10.3.1
     - bin/test UIKit-iOS 11.0
     - bin/test UIKit-iOS 10.3.1
-    - bin/test tvOS 10.2
-    - bin/test UIKit-tvOS 10.2
 experimental:
   notify:
     branches:


### PR DESCRIPTION
Allows us to use Swift 4 key paths for lenses! Won't need to build bespoke lenses so often!

``` swift
// before
public let activitySampleProjectSubtitleLabelStyle =
  UILabel.lens.textColor .~ .ksr_text_dark_grey_400
    <> UILabel.lens.numberOfLines .~ 2
    <> UILabel.lens.lineBreakMode .~ .byTruncatingTail
    <> UILabel.lens.font .~ .ksr_subhead()

// after
public let activitySampleProjectSubtitleLabelStyle =
  (\UILabel.textColor) .~ .ksr_text_dark_grey_400
    <> \.numberOfLines .~ 2
    <> \.lineBreakMode .~ .byTruncatingTail
    <> \.font .~ .ksr_subhead()
```