### PR TITLE
Move Runes to HTTPS, update tvOS target to Swift 4.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Frameworks/Runes"]
 	path = Frameworks/Runes
-	url = git://github.com/thoughtbot/Runes.git
+	url = https://github.com/thoughtbot/Runes.git

--- a/Prelude-UIKit/UIButton.swift
+++ b/Prelude-UIKit/UIButton.swift
@@ -7,7 +7,7 @@ extension UIButton {
    - parameter backgroundColor: The color to set.
    - parameter state:           The state for the color to take affect.
    */
-  public func setBackgroundColor(_ backgroundColor: UIColor, for state: UIControlState) {
+  public func setBackgroundColor(_ backgroundColor: UIColor, for state: UIControl.State) {
     self.setBackgroundImage(.pixel(ofColor: backgroundColor), for: state)
   }
 }

--- a/Prelude-UIKit/lenses/UIActivityIndicatorViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIActivityIndicatorViewLenses.swift
@@ -2,8 +2,16 @@ import Prelude
 import UIKit
 
 public protocol UIActivityIndicatorViewProtocol: UIViewProtocol {
-  var activityIndicatorViewStyle: UIActivityIndicatorViewStyle { get set }
+  #if os(iOS)
+  var activityIndicatorViewStyle: UIActivityIndicatorView.Style { get set }
+  #elseif os(tvOS)
+  var style: UIActivityIndicatorView.Style { get set }
+  #endif
+  #if os(iOS)
   var color: UIColor? { get set }
+  #elseif os(tvOS)
+  var color: UIColor! { get set }
+  #endif
   var hidesWhenStopped: Bool { get set }
   var isAnimating: Bool { get }
   func startAnimating()
@@ -14,12 +22,21 @@ extension UIActivityIndicatorView: UIActivityIndicatorViewProtocol {}
 
 public extension LensHolder where Object: UIActivityIndicatorViewProtocol {
 
-  public var activityIndicatorViewStyle: Lens<Object, UIActivityIndicatorViewStyle> {
+  #if os(iOS)
+  public var activityIndicatorViewStyle: Lens<Object, UIActivityIndicatorView.Style> {
     return Lens(
       view: { $0.activityIndicatorViewStyle },
       set: { $1.activityIndicatorViewStyle = $0; return $1 }
     )
   }
+  #elseif os(tvOS)
+  public var style: Lens<Object, UIActivityIndicatorView.Style> {
+    return Lens(
+      view: { $0.style },
+      set: { $1.style = $0; return $1 }
+    )
+  }
+  #endif
 
   public var animating: Lens<Object, Bool> {
     return Lens(
@@ -28,12 +45,21 @@ public extension LensHolder where Object: UIActivityIndicatorViewProtocol {
     )
   }
 
+  #if os(iOS)
   public var color: Lens<Object, UIColor?> {
     return Lens(
       view: { $0.color },
       set: { $1.color = $0; return $1 }
     )
   }
+  #elseif os(tvOS)
+  public var color: Lens<Object, UIColor> {
+    return Lens(
+      view: { $0.color },
+      set: { $1.color = $0; return $1 }
+    )
+  }
+  #endif
 
   public var hidesWhenStopped: Lens<Object, Bool> {
     return Lens(

--- a/Prelude-UIKit/lenses/UIButtonLenses.swift
+++ b/Prelude-UIKit/lenses/UIButtonLenses.swift
@@ -4,22 +4,22 @@ import UIKit
 public protocol UIButtonProtocol: UIControlProtocol {
   var adjustsImageWhenDisabled: Bool { get set }
   var adjustsImageWhenHighlighted: Bool { get set }
-  func attributedTitle(for state: UIControlState) -> NSAttributedString?
-  func backgroundImage(for state: UIControlState) -> UIImage?
+  func attributedTitle(for state: UIControl.State) -> NSAttributedString?
+  func backgroundImage(for state: UIControl.State) -> UIImage?
   var contentEdgeInsets: UIEdgeInsets { get set }
   var imageEdgeInsets: UIEdgeInsets { get set }
-  func image(for state: UIControlState) -> UIImage?
+  func image(for state: UIControl.State) -> UIImage?
   var imageView: UIImageView? { get }
   func setAttributedTitle(_ title: NSAttributedString?,
-                          for state: UIControlState)
-  func setBackgroundColor(_ backgroundColor: UIColor, for state: UIControlState)
-  func setBackgroundImage(_ backgroundImage: UIImage?, for state: UIControlState)
-  func setImage(_ image: UIImage?, for: UIControlState)
-  func setTitle(_ title: String?, for: UIControlState)
-  func setTitleColor(_ color: UIColor?, for: UIControlState)
-  func titleColor(for state: UIControlState) -> UIColor?
+                          for state: UIControl.State)
+  func setBackgroundColor(_ backgroundColor: UIColor, for state: UIControl.State)
+  func setBackgroundImage(_ backgroundImage: UIImage?, for state: UIControl.State)
+  func setImage(_ image: UIImage?, for: UIControl.State)
+  func setTitle(_ title: String?, for: UIControl.State)
+  func setTitleColor(_ color: UIColor?, for: UIControl.State)
+  func titleColor(for state: UIControl.State) -> UIColor?
   var titleEdgeInsets: UIEdgeInsets { get set }
-  func title(for state: UIControlState) -> String?
+  func title(for state: UIControl.State) -> String?
   var titleLabel: UILabel? { get }
 }
 
@@ -40,21 +40,21 @@ public extension LensHolder where Object: UIButtonProtocol {
     )
   }
 
-  public func attributedTitle(for state: UIControlState) -> Lens<Object, NSAttributedString> {
+  public func attributedTitle(for state: UIControl.State) -> Lens<Object, NSAttributedString> {
     return Lens(
       view: { $0.attributedTitle(for: state) ?? NSAttributedString(string: "") },
       set: { $1.setAttributedTitle($0, for: state); return $1 }
     )
   }
 
-  public func backgroundColor(for state: UIControlState) -> Lens<Object, UIColor> {
+  public func backgroundColor(for state: UIControl.State) -> Lens<Object, UIColor> {
     return Lens(
       view: { _ in .clear },
       set: { $1.setBackgroundColor($0, for: state); return $1 }
     )
   }
 
-  public func backgroundImage(for state: UIControlState) -> Lens<Object, UIImage?> {
+  public func backgroundImage(for state: UIControl.State) -> Lens<Object, UIImage?> {
     return Lens(
       view: { $0.backgroundImage(for: state) },
       set: { $1.setBackgroundImage($0, for: state); return $1 }
@@ -75,7 +75,7 @@ public extension LensHolder where Object: UIButtonProtocol {
     )
   }
 
-  public func image(for state: UIControlState) -> Lens<Object, UIImage?> {
+  public func image(for state: UIControl.State) -> Lens<Object, UIImage?> {
     return Lens(
       view: { $0.image(for: state) },
       set: { $1.setImage($0, for: state); return $1 }
@@ -89,7 +89,7 @@ public extension LensHolder where Object: UIButtonProtocol {
     )
   }
 
-  public func titleColor(for state: UIControlState) -> Lens<Object, UIColor> {
+  public func titleColor(for state: UIControl.State) -> Lens<Object, UIColor> {
     return Lens(
       view: { $0.titleColor(for: state) ?? .clear },
       set: { $1.setTitleColor($0, for: state); return $1 }
@@ -110,7 +110,7 @@ public extension LensHolder where Object: UIButtonProtocol {
     )
   }
 
-  public func title(for state: UIControlState) -> Lens<Object, String?> {
+  public func title(for state: UIControl.State) -> Lens<Object, String?> {
     return Lens(
       view: { $0.title(for: state) },
       set: { $1.setTitle($0, for: state); return $1 }

--- a/Prelude-UIKit/lenses/UIControlLenses.swift
+++ b/Prelude-UIKit/lenses/UIControlLenses.swift
@@ -1,18 +1,18 @@
 import Prelude
 import UIKit
 
-public typealias TargetSelectorControlEvent = (Any, Selector, UIControlEvents)
+public typealias TargetSelectorControlEvent = (Any, Selector, UIControl.Event)
 
 public protocol UIControlProtocol: UIViewProtocol {
-  func actions(forTarget target: Any?, forControlEvent controlEvent: UIControlEvents) -> [String]?
-  func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControlEvents)
-  var allControlEvents: UIControlEvents { get }
+  func actions(forTarget target: Any?, forControlEvent controlEvent: UIControl.Event) -> [String]?
+  func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event)
+  var allControlEvents: UIControl.Event { get }
   var allTargets: Set<AnyHashable> { get }
-  var contentHorizontalAlignment: UIControlContentHorizontalAlignment { get set }
-  var contentVerticalAlignment: UIControlContentVerticalAlignment { get set }
+  var contentHorizontalAlignment: UIControl.ContentHorizontalAlignment { get set }
+  var contentVerticalAlignment: UIControl.ContentVerticalAlignment { get set }
   var isEnabled: Bool { get set }
   var isHighlighted: Bool { get set }
-  func removeTarget(_ target: Any?, action: Selector?, for controlEvents: UIControlEvents)
+  func removeTarget(_ target: Any?, action: Selector?, for controlEvents: UIControl.Event)
   var isSelected: Bool { get set }
 }
 
@@ -31,14 +31,14 @@ public extension LensHolder where Object: UIControlProtocol {
     )
   }
 
-  public var contentHorizontalAlignment: Lens<Object, UIControlContentHorizontalAlignment> {
+  public var contentHorizontalAlignment: Lens<Object, UIControl.ContentHorizontalAlignment> {
     return Lens(
       view: { $0.contentHorizontalAlignment },
       set: { $1.contentHorizontalAlignment = $0; return $1 }
     )
   }
 
-  public var contentVerticalAlignment: Lens<Object, UIControlContentVerticalAlignment> {
+  public var contentVerticalAlignment: Lens<Object, UIControl.ContentVerticalAlignment> {
     return Lens(
       view: { $0.contentVerticalAlignment },
       set: { $1.contentVerticalAlignment = $0; return $1 }
@@ -78,7 +78,7 @@ private func allTargetsSelectorsAndEvents(for control: UIControlProtocol)
   -> [TargetSelectorControlEvent] {
 
     return bitComponents(forMask: control.allControlEvents.rawValue)
-      .map(UIControlEvents.init(rawValue:))
+      .map(UIControl.Event.init(rawValue:))
       .flatMap { event in
         control.allTargets
           .flatMap { target in

--- a/Prelude-UIKit/lenses/UIProgressViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIProgressViewLenses.swift
@@ -2,7 +2,7 @@ import Prelude
 import UIKit
 
 public protocol UIProgressViewProtocol: UIViewProtocol {
-  var progressViewStyle: UIProgressViewStyle { get set }
+  var progressViewStyle: UIProgressView.Style { get set }
   var progress: Float { get set }
 }
 
@@ -10,7 +10,7 @@ extension UIProgressView: UIProgressViewProtocol {}
 
 public extension LensHolder where Object: UIProgressViewProtocol {
 
-  public var progressViewStyle: Lens<Object, UIProgressViewStyle> {
+  public var progressViewStyle: Lens<Object, UIProgressView.Style> {
     return Lens(
       view: { $0.progressViewStyle },
       set: { $1.progressViewStyle = $0; return $1 }

--- a/Prelude-UIKit/lenses/UIScrollViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIScrollViewLenses.swift
@@ -3,12 +3,14 @@ import UIKit
 
 public protocol UIScrollViewProtocol: UIViewProtocol {
   var canCancelContentTouches: Bool { get set }
-  var decelerationRate: CGFloat { get set }
+  var decelerationRate: UIScrollView.DecelerationRate { get set }
   var delaysContentTouches: Bool { get set }
-  var keyboardDismissMode: UIScrollViewKeyboardDismissMode { get set }
+  var keyboardDismissMode: UIScrollView.KeyboardDismissMode { get set }
   var isScrollEnabled: Bool { get set }
   var scrollIndicatorInsets: UIEdgeInsets { get set }
+  #if os(iOS)
   var scrollsToTop: Bool { get set }
+  #endif
   var showsHorizontalScrollIndicator: Bool { get set }
   var showsVerticalScrollIndicator: Bool { get set }
 }
@@ -24,7 +26,7 @@ public extension LensHolder where Object: UIScrollViewProtocol {
     )
   }
 
-  public var decelerationRate: Lens<Object, CGFloat> {
+  public var decelerationRate: Lens<Object, UIScrollView.DecelerationRate> {
     return Lens(
       view: { $0.decelerationRate },
       set: { $1.decelerationRate = $0; return $1 }
@@ -45,7 +47,7 @@ public extension LensHolder where Object: UIScrollViewProtocol {
     )
   }
 
-  public var keyboardDismissMode: Lens<Object, UIScrollViewKeyboardDismissMode> {
+  public var keyboardDismissMode: Lens<Object, UIScrollView.KeyboardDismissMode> {
     return Lens(
       view: { $0.keyboardDismissMode },
       set: { $1.keyboardDismissMode = $0; return $1 }
@@ -59,12 +61,14 @@ public extension LensHolder where Object: UIScrollViewProtocol {
     )
   }
 
+  #if os(iOS)
   public var scrollsToTop: Lens<Object, Bool> {
     return Lens(
       view: { $0.scrollsToTop },
       set: { $1.scrollsToTop = $0; return $1 }
     )
   }
+  #endif
 
   public var showsHorizontalScrollIndicator: Lens<Object, Bool> {
     return Lens(

--- a/Prelude-UIKit/lenses/UIStackViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIStackViewLenses.swift
@@ -3,11 +3,11 @@ import UIKit
 
 public protocol UIStackViewProtocol: UIViewProtocol {
   func addArrangedSubview(_ view: UIView)
-  var alignment: UIStackViewAlignment { get set }
+  var alignment: UIStackView.Alignment { get set }
   var arrangedSubviews: [UIView] { get }
-  var axis: UILayoutConstraintAxis { get set }
+  var axis: NSLayoutConstraint.Axis { get set }
   var isBaselineRelativeArrangement: Bool { get set }
-  var distribution: UIStackViewDistribution { get set }
+  var distribution: UIStackView.Distribution { get set }
   var isLayoutMarginsRelativeArrangement: Bool { get set }
   var spacing: CGFloat { get set }
 }
@@ -15,7 +15,7 @@ public protocol UIStackViewProtocol: UIViewProtocol {
 extension UIStackView: UIStackViewProtocol {}
 
 public extension LensHolder where Object: UIStackViewProtocol {
-  public var alignment: Lens<Object, UIStackViewAlignment> {
+  public var alignment: Lens<Object, UIStackView.Alignment> {
     return Lens(
       view: { $0.alignment },
       set: { $1.alignment = $0; return $1 }
@@ -33,12 +33,14 @@ public extension LensHolder where Object: UIStackViewProtocol {
     )
   }
 
-  public var axis: Lens<Object, UILayoutConstraintAxis> {
+  #if os(iOS)
+  public var axis: Lens<Object, NSLayoutConstraint.Axis> {
     return Lens(
       view: { $0.axis },
       set: { $1.axis = $0; return $1 }
     )
   }
+  #endif
 
   public var isBaselineRelativeArrangement: Lens<Object, Bool> {
     return Lens(
@@ -47,7 +49,7 @@ public extension LensHolder where Object: UIStackViewProtocol {
     )
   }
 
-  public var distribution: Lens<Object, UIStackViewDistribution> {
+  public var distribution: Lens<Object, UIStackView.Distribution> {
     return Lens(
       view: { $0.distribution },
       set: { $1.distribution = $0; return $1 }

--- a/Prelude-UIKit/lenses/UISwitchLenses.swift
+++ b/Prelude-UIKit/lenses/UISwitchLenses.swift
@@ -8,7 +8,9 @@ public protocol UISwitchProtocol: UIControlProtocol {
   var tintColor: UIColor! { get set }
 }
 
+#if os(iOS)
 extension UISwitch: UISwitchProtocol {}
+#endif
 
 public extension LensHolder where Object: UISwitchProtocol {
 

--- a/Prelude-UIKit/lenses/UITableViewCellLenses.swift
+++ b/Prelude-UIKit/lenses/UITableViewCellLenses.swift
@@ -3,7 +3,7 @@ import UIKit
 
 public protocol UITableViewCellProtocol: UIViewProtocol {
   var contentView: UIView { get }
-  var selectionStyle: UITableViewCellSelectionStyle { get set }
+  var selectionStyle: UITableViewCell.SelectionStyle { get set }
 }
 
 extension UITableViewCell: UITableViewCellProtocol {}
@@ -16,7 +16,7 @@ public extension LensHolder where Object: UITableViewCellProtocol {
     )
   }
 
-  public var selectionStyle: Lens<Object, UITableViewCellSelectionStyle> {
+  public var selectionStyle: Lens<Object, UITableViewCell.SelectionStyle> {
     return Lens(
       view: { $0.selectionStyle },
       set: { $1.selectionStyle = $0; return $1 }

--- a/Prelude-UIKit/lenses/UITextFieldLenses.swift
+++ b/Prelude-UIKit/lenses/UITextFieldLenses.swift
@@ -2,7 +2,7 @@ import Prelude
 import UIKit
 
 public protocol UITextFieldProtocol: UIControlProtocol, UITextInputTraitsProtocol {
-  var borderStyle: UITextBorderStyle { get set }
+  var borderStyle: UITextField.BorderStyle { get set }
   var font: UIFont? { get set }
   var placeholder: String? { get set }
   var textAlignment: NSTextAlignment { get set }
@@ -14,7 +14,7 @@ extension UITextField: UITextFieldProtocol {}
 
 public extension LensHolder where Object: UITextFieldProtocol {
 
-  public var borderStyle: Lens<Object, UITextBorderStyle> {
+  public var borderStyle: Lens<Object, UITextField.BorderStyle> {
     return Lens(
       view: { $0.borderStyle },
       set: { $1.borderStyle = $0; return $1 }

--- a/Prelude-UIKit/lenses/UIViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIViewLenses.swift
@@ -7,9 +7,9 @@ public protocol UIViewProtocol: KSObjectProtocol, UITraitEnvironmentProtocol, Le
   var backgroundColor: UIColor? { get set }
   var clipsToBounds: Bool { get set }
   var constraints: [NSLayoutConstraint] { get }
-  func contentCompressionResistancePriority(for axis: UILayoutConstraintAxis) -> UILayoutPriority
-  func contentHuggingPriority(for axis: UILayoutConstraintAxis) -> UILayoutPriority
-  var contentMode: UIViewContentMode { get set }
+  func contentCompressionResistancePriority(for axis: NSLayoutConstraint.Axis) -> UILayoutPriority
+  func contentHuggingPriority(for axis: NSLayoutConstraint.Axis) -> UILayoutPriority
+  var contentMode: UIView.ContentMode { get set }
   var frame: CGRect { get set }
   var isHidden: Bool { get set }
   var layer: CALayer { get }
@@ -18,9 +18,9 @@ public protocol UIViewProtocol: KSObjectProtocol, UITraitEnvironmentProtocol, Le
   func removeConstraints(_ constraints: [NSLayoutConstraint])
   var semanticContentAttribute: UISemanticContentAttribute { get set }
   func setContentCompressionResistancePriority(_ priority: UILayoutPriority,
-                                               for axis: UILayoutConstraintAxis)
+                                               for axis: NSLayoutConstraint.Axis)
   func setContentHuggingPriority(_ priority: UILayoutPriority,
-                                 for axis: UILayoutConstraintAxis)
+                                 for axis: NSLayoutConstraint.Axis)
   var tag: Int { get set }
   var tintColor: UIColor! { get set }
   var translatesAutoresizingMaskIntoConstraints: Bool { get set }
@@ -62,7 +62,7 @@ public extension LensHolder where Object: UIViewProtocol {
     )
   }
 
-  public func contentCompressionResistancePriority(for axis: UILayoutConstraintAxis)
+  public func contentCompressionResistancePriority(for axis: NSLayoutConstraint.Axis)
     -> Lens<Object, UILayoutPriority> {
 
     return Lens(
@@ -71,7 +71,7 @@ public extension LensHolder where Object: UIViewProtocol {
     )
   }
 
-  public func contentHuggingPriority(for axis: UILayoutConstraintAxis)
+  public func contentHuggingPriority(for axis: NSLayoutConstraint.Axis)
     -> Lens<Object, UILayoutPriority> {
 
       return Lens(
@@ -80,7 +80,7 @@ public extension LensHolder where Object: UIViewProtocol {
       )
   }
 
-  public var contentMode: Lens<Object, UIViewContentMode> {
+  public var contentMode: Lens<Object, UIView.ContentMode> {
     return Lens(
       view: { $0.contentMode },
       set: { $1.contentMode = $0; return $1 }

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -1396,7 +1396,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.Prelude;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1416,7 +1415,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.Prelude;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1509,7 +1507,7 @@
 				SDKROOT = appletvos;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1567,7 +1565,7 @@
 				SDKROOT = appletvos;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
This updates our tvOS targets to Swift 4.2. Although we don't use tvOS in our app repo currently, it might be in use in other OSS projects and I think it's ok to keep it up to date for now.

I missed the tvOS updates in #89 because the language version was being set at a target instead of project level.

Also, in order to try to get this working on Apple's CI for the Swift compatibility suite (https://github.com/apple/swift-source-compat-suite/pull/211) we need to point the Runes dependency at HTTPS instead of SSH.