### PR TITLE
[NT-723] Xcode 11/Swift 5.1 updates

### DIFF
--- a/Prelude-UIKit/lenses/UIActivityIndicatorViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIActivityIndicatorViewLenses.swift
@@ -2,16 +2,8 @@ import Prelude
 import UIKit
 
 public protocol UIActivityIndicatorViewProtocol: UIViewProtocol {
-  #if os(iOS)
-  var activityIndicatorViewStyle: UIActivityIndicatorView.Style { get set }
-  #elseif os(tvOS)
   var style: UIActivityIndicatorView.Style { get set }
-  #endif
-  #if os(iOS)
-  var color: UIColor? { get set }
-  #elseif os(tvOS)
   var color: UIColor! { get set }
-  #endif
   var hidesWhenStopped: Bool { get set }
   var isAnimating: Bool { get }
   func startAnimating()
@@ -22,21 +14,12 @@ extension UIActivityIndicatorView: UIActivityIndicatorViewProtocol {}
 
 public extension LensHolder where Object: UIActivityIndicatorViewProtocol {
 
-  #if os(iOS)
-  public var activityIndicatorViewStyle: Lens<Object, UIActivityIndicatorView.Style> {
-    return Lens(
-      view: { $0.activityIndicatorViewStyle },
-      set: { $1.activityIndicatorViewStyle = $0; return $1 }
-    )
-  }
-  #elseif os(tvOS)
   public var style: Lens<Object, UIActivityIndicatorView.Style> {
     return Lens(
       view: { $0.style },
       set: { $1.style = $0; return $1 }
     )
   }
-  #endif
 
   public var animating: Lens<Object, Bool> {
     return Lens(
@@ -45,21 +28,12 @@ public extension LensHolder where Object: UIActivityIndicatorViewProtocol {
     )
   }
 
-  #if os(iOS)
-  public var color: Lens<Object, UIColor?> {
-    return Lens(
-      view: { $0.color },
-      set: { $1.color = $0; return $1 }
-    )
-  }
-  #elseif os(tvOS)
   public var color: Lens<Object, UIColor> {
     return Lens(
       view: { $0.color },
       set: { $1.color = $0; return $1 }
     )
   }
-  #endif
 
   public var hidesWhenStopped: Lens<Object, Bool> {
     return Lens(

--- a/Prelude-UIKit/lenses/UIBarButtonItemLenses.swift
+++ b/Prelude-UIKit/lenses/UIBarButtonItemLenses.swift
@@ -2,26 +2,26 @@ import Prelude
 import UIKit
 
 public protocol UIBarButtonItemProtocol: UIBarItemProtocol {
-  var style: UIBarButtonItemStyle { get set }
+  var style: UIBarButtonItem.Style { get set }
   var width: CGFloat { get set }
   var possibleTitles: Set<String>? { get set }
   var customView: UIView? { get set }
   var action: Selector? { get set }
   var target: AnyObject? { get set }
-  func setBackgroundImage(_ backgroundImage: UIImage?, for state: UIControlState, barMetrics: UIBarMetrics)
-  func backgroundImage(for state: UIControlState, barMetrics: UIBarMetrics) -> UIImage?
-  func setBackgroundImage(_ backgroundImage: UIImage?, for state: UIControlState, style: UIBarButtonItemStyle,
-                          barMetrics: UIBarMetrics)
-  func backgroundImage(for state: UIControlState, style: UIBarButtonItemStyle, barMetrics: UIBarMetrics)
+  func setBackgroundImage(_ backgroundImage: UIImage?, for state: UIControl.State, barMetrics: UIBarMetrics)
+  func backgroundImage(for state: UIControl.State, barMetrics: UIBarMetrics) -> UIImage?
+  func setBackgroundImage(_ backgroundImage: UIImage?, for state: UIControl.State,
+                          style: UIBarButtonItem.Style, barMetrics: UIBarMetrics)
+  func backgroundImage(for state: UIControl.State, style: UIBarButtonItem.Style, barMetrics: UIBarMetrics)
     -> UIImage?
   var tintColor: UIColor? { get set }
   func setBackgroundVerticalPositionAdjustment(_ adjustment: CGFloat, for barMetrics: UIBarMetrics)
   func backgroundVerticalPositionAdjustment(for barMetrics: UIBarMetrics) -> CGFloat
   func setTitlePositionAdjustment(_ adjustment: UIOffset, for barMetrics: UIBarMetrics)
   func titlePositionAdjustment(for barMetrics: UIBarMetrics) -> UIOffset
-  func setBackButtonBackgroundImage(_ backgroundImage: UIImage?, for state: UIControlState,
+  func setBackButtonBackgroundImage(_ backgroundImage: UIImage?, for state: UIControl.State,
                                     barMetrics: UIBarMetrics)
-  func backButtonBackgroundImage(for state: UIControlState, barMetrics: UIBarMetrics) -> UIImage?
+  func backButtonBackgroundImage(for state: UIControl.State, barMetrics: UIBarMetrics) -> UIImage?
   func setBackButtonTitlePositionAdjustment(_ adjustment: UIOffset, for barMetrics: UIBarMetrics)
   func backButtonTitlePositionAdjustment(for barMetrics: UIBarMetrics) -> UIOffset
   func setBackButtonBackgroundVerticalPositionAdjustment(_ adjustment: CGFloat, for barMetrics: UIBarMetrics)
@@ -31,7 +31,7 @@ public protocol UIBarButtonItemProtocol: UIBarItemProtocol {
 extension UIBarButtonItem: UIBarButtonItemProtocol {}
 
 public extension LensHolder where Object: UIBarButtonItemProtocol {
-  public var style: Lens<Object, UIBarButtonItemStyle> {
+  public var style: Lens<Object, UIBarButtonItem.Style> {
     return Lens(
       view: { $0.style },
       set: { $1.style = $0; return $1 }
@@ -69,7 +69,7 @@ public extension LensHolder where Object: UIBarButtonItemProtocol {
     )
   }
 
-  public func backgroundImage(forState state: UIControlState, barMetrics: UIBarMetrics)
+  public func backgroundImage(forState state: UIControl.State, barMetrics: UIBarMetrics)
     -> Lens<Object, UIImage?> {
 
       return Lens(
@@ -78,8 +78,8 @@ public extension LensHolder where Object: UIBarButtonItemProtocol {
       )
   }
 
-  public func backgroundImage(forState state: UIControlState,
-                              style: UIBarButtonItemStyle,
+  public func backgroundImage(forState state: UIControl.State,
+                              style: UIBarButtonItem.Style,
                               barMetrics: UIBarMetrics) -> Lens<Object, UIImage?> {
     return Lens(
       view: { $0.backgroundImage(for: state, style: style, barMetrics: barMetrics) },
@@ -110,7 +110,7 @@ public extension LensHolder where Object: UIBarButtonItemProtocol {
     )
   }
 
-  public func backButtonBackgroundImage(forState state: UIControlState, barMetrics: UIBarMetrics)
+  public func backButtonBackgroundImage(forState state: UIControl.State, barMetrics: UIBarMetrics)
     -> Lens<Object, UIImage?> {
 
       return Lens(

--- a/Prelude-UIKit/lenses/UINavigationBarLenses.swift
+++ b/Prelude-UIKit/lenses/UINavigationBarLenses.swift
@@ -6,7 +6,7 @@ public protocol UINavigationBarProtocol: UIViewProtocol {
   var barTintColor: UIColor? { get set }
   func setBackgroundImage(_ backgroundImage: UIImage?, for barMetrics: UIBarMetrics)
   var shadowImage: UIImage? { get set }
-  var titleTextAttributes: [NSAttributedStringKey: Any]? { get set }
+  var titleTextAttributes: [NSAttributedString.Key: Any]? { get set }
   var isTranslucent: Bool { get set }
 }
 
@@ -39,7 +39,7 @@ public extension LensHolder where Object: UINavigationBarProtocol {
     )
   }
 
-  public var titleTextAttributes: Lens<Object, [NSAttributedStringKey: Any]> {
+  public var titleTextAttributes: Lens<Object, [NSAttributedString.Key: Any]> {
     return Lens(
       view: { $0.titleTextAttributes ?? [:] },
       set: { $1.titleTextAttributes = $0; return $1; }

--- a/Prelude-UIKit/lenses/UITableViewControllerLenses.swift
+++ b/Prelude-UIKit/lenses/UITableViewControllerLenses.swift
@@ -28,7 +28,7 @@ extension Lens where Whole: UITableViewControllerProtocol, Part == UITableView {
   }
 
   #if os(iOS)
-  public var separatorStyle: Lens<Whole, UITableViewCellSeparatorStyle> {
+  public var separatorStyle: Lens<Whole, UITableViewCell.SeparatorStyle> {
     return Whole.lens.tableView..Part.lens.separatorStyle
   }
   #endif

--- a/Prelude-UIKit/lenses/UITableViewLenses.swift
+++ b/Prelude-UIKit/lenses/UITableViewLenses.swift
@@ -13,7 +13,7 @@ public protocol UITableViewProtocol: UIViewProtocol {
   #if os(iOS)
   var separatorColor: UIColor? { get set }
   var separatorEffect: UIVisualEffect? { get set }
-  var separatorStyle: UITableViewCellSeparatorStyle { get set }
+  var separatorStyle: UITableViewCell.SeparatorStyle { get set }
   #endif
 }
 
@@ -92,7 +92,7 @@ public extension LensHolder where Object: UITableViewProtocol {
     )
   }
 
-  public var separatorStyle: Lens<Object, UITableViewCellSeparatorStyle> {
+  public var separatorStyle: Lens<Object, UITableViewCell.SeparatorStyle> {
     return Lens(
       view: { $0.separatorStyle },
       set: { $1.separatorStyle = $0; return $1 }

--- a/Prelude-UIKit/lenses/UIWebViewLenses.swift
+++ b/Prelude-UIKit/lenses/UIWebViewLenses.swift
@@ -31,7 +31,7 @@ extension Lens where Whole: UIWebViewProtocol, Part == UIScrollView {
     return Whole.lens.scrollView..Part.lens.delaysContentTouches
   }
 
-  public var decelerationRate: Lens<Whole, CGFloat> {
+  public var decelerationRate: Lens<Whole, UIScrollView.DecelerationRate> {
     return Whole.lens.scrollView..Part.lens.decelerationRate
   }
 }

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -838,6 +838,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = CA0923EE1BB6291800C9EC88;
@@ -1282,7 +1283,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Prelude-UIKit-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1296,7 +1296,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Prelude-UIKit-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -1319,7 +1318,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1342,7 +1340,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1361,7 +1358,6 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1378,7 +1374,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1432,7 +1427,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1447,7 +1441,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.PreludeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1509,7 +1502,7 @@
 				SDKROOT = appletvos;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.4;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1567,7 +1560,7 @@
 				SDKROOT = appletvos;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.4;
 				VALIDATE_PRODUCT = YES;
@@ -1618,7 +1611,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.PreludeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1631,7 +1623,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.PreludeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Prelude/Lens.swift
+++ b/Prelude/Lens.swift
@@ -178,8 +178,7 @@ public func lens<Whole, Part>(_ keyPath: WritableKeyPath<Whole, Part>) -> Lens<W
 
  - returns: A function that transforms a whole into a new whole with a part replaced.
  */
-public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?, part: Part) -> ((Whole) -> Whole) {
-  guard let keyPath = keyPath else { return { $0 } }
+public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, part: Part) -> ((Whole) -> Whole) {
   return lens(keyPath) .~ part
 }
 
@@ -191,9 +190,8 @@ public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?, part: Part
 
  - returns: A function that transforms a whole into a new whole with its part transformed by `f`.
  */
-public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?, f: @escaping (Part) -> Part)
+public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, f: @escaping (Part) -> Part)
   -> ((Whole) -> Whole) {
-    guard let keyPath = keyPath else { return { $0 } }
     return lens(keyPath) %~ f
 }
 
@@ -205,9 +203,8 @@ public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?, f: @escapi
 
  - returns: A function that transforms a whole into a new whole with its part transformed by `f`.
  */
-public func %~~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?,
+public func %~~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>,
                                f: @escaping (Part, Whole) -> Part) -> ((Whole) -> Whole) {
-  guard let keyPath = keyPath else { return { $0 } }
   return lens(keyPath) %~~ f
 }
 
@@ -219,9 +216,8 @@ public func %~~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?,
 
  - returns: A function that transform a whole into a new whole with its part concatenated to `a`.
  */
-public func <>~ <Whole, Part: Semigroup> (keyPath: WritableKeyPath<Whole, Part>?, a: Part)
+public func <>~ <Whole, Part: Semigroup> (keyPath: WritableKeyPath<Whole, Part>, a: Part)
   -> ((Whole) -> Whole) {
-    guard let keyPath = keyPath else { return { $0 } }
     return lens(keyPath) <>~ a
 }
 

--- a/Prelude/Lens.swift
+++ b/Prelude/Lens.swift
@@ -166,7 +166,7 @@ public func lens<Whole, Part>(_ keyPath: WritableKeyPath<Whole, Part>) -> Lens<W
       var copy = whole
       copy[keyPath: keyPath] = part
       return copy
-  }
+    }
   )
 }
 
@@ -183,6 +183,13 @@ public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, part: Part)
 }
 
 /**
+* Overload for .~ with an optional Part
+*/
+public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part?>, part: Part) -> ((Whole) -> Whole) {
+  return lens(keyPath) .~ part
+}
+
+/**
  Infix operator of the `over` function.
 
  - parameter keyPath: A key path.
@@ -191,6 +198,14 @@ public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, part: Part)
  - returns: A function that transforms a whole into a new whole with its part transformed by `f`.
  */
 public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, f: @escaping (Part) -> Part)
+  -> ((Whole) -> Whole) {
+    return lens(keyPath) %~ f
+}
+
+/**
+ * Overload for ~% with an optional Part
+ */
+public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part?>, f: @escaping (Part?) -> Part)
   -> ((Whole) -> Whole) {
     return lens(keyPath) %~ f
 }

--- a/Prelude/Lens.swift
+++ b/Prelude/Lens.swift
@@ -178,7 +178,8 @@ public func lens<Whole, Part>(_ keyPath: WritableKeyPath<Whole, Part>) -> Lens<W
 
  - returns: A function that transforms a whole into a new whole with a part replaced.
  */
-public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, part: Part) -> ((Whole) -> Whole) {
+public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?, part: Part) -> ((Whole) -> Whole) {
+  guard let keyPath = keyPath else { return { $0 } }
   return lens(keyPath) .~ part
 }
 
@@ -190,9 +191,9 @@ public func .~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, part: Part)
 
  - returns: A function that transforms a whole into a new whole with its part transformed by `f`.
  */
-public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, f: @escaping (Part) -> Part)
+public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?, f: @escaping (Part) -> Part)
   -> ((Whole) -> Whole) {
-
+    guard let keyPath = keyPath else { return { $0 } }
     return lens(keyPath) %~ f
 }
 
@@ -204,9 +205,9 @@ public func %~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>, f: @escapin
 
  - returns: A function that transforms a whole into a new whole with its part transformed by `f`.
  */
-public func %~~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>,
+public func %~~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>?,
                                f: @escaping (Part, Whole) -> Part) -> ((Whole) -> Whole) {
-
+  guard let keyPath = keyPath else { return { $0 } }
   return lens(keyPath) %~~ f
 }
 
@@ -218,9 +219,9 @@ public func %~~ <Whole, Part> (keyPath: WritableKeyPath<Whole, Part>,
 
  - returns: A function that transform a whole into a new whole with its part concatenated to `a`.
  */
-public func <>~ <Whole, Part: Semigroup> (keyPath: WritableKeyPath<Whole, Part>, a: Part)
+public func <>~ <Whole, Part: Semigroup> (keyPath: WritableKeyPath<Whole, Part>?, a: Part)
   -> ((Whole) -> Whole) {
-
+    guard let keyPath = keyPath else { return { $0 } }
     return lens(keyPath) <>~ a
 }
 
@@ -231,7 +232,7 @@ public extension KeyPath {
   It's similar to the `view` property of Lenses.
 */
 
-  public var view: (Root) -> Value {
+  var view: (Root) -> Value {
     return { whole in
       whole[keyPath: self]
     }

--- a/Prelude/LensTests.swift
+++ b/Prelude/LensTests.swift
@@ -96,12 +96,19 @@ final class LensTests: XCTestCase {
     let name = newUser |> (\User.name).view
     XCTAssertEqual(newUser.name, name)
   }
+
+  func testOptionalKeyPathSetter() {
+    let newUser = user
+      |> \.title .~ "King"
+    XCTAssertEqual(newUser.title, "King")
+  }
 }
 
 private struct User: Equatable {
   private(set) var id: Int
   private(set) var location: Location
   private(set) var name: String
+  public var title: String?
 
   static let _id = Lens<User, Int>(
     view: { $0.id },

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -26,7 +26,6 @@ extension OptionalType {
     return self.optional!
   }
 
-  // swiftlint:disable valid_docs
   /**
    Call `body` on wrapped value of `self` if present. An analog to `Sequence.forEach`.
 
@@ -37,7 +36,6 @@ extension OptionalType {
       try body(value)
     }
   }
-  // swiftlint:enable valid_docs
 
   /**
    - parameter predicate: A predicate that determines if the wrapped value should be kept or not.
@@ -96,6 +94,7 @@ public func == <A: Equatable> (lhs: [A?], rhs: [A?]) -> Bool {
   guard lhs.count == rhs.count else { return false }
 
   return zip(lhs, rhs).reduce(true) { (accum, lr) in
+    // swiftlint:disable:next reduce_boolean
     return accum && lr.0 == lr.1
   }
 }

--- a/Prelude/Optional.swift
+++ b/Prelude/Optional.swift
@@ -93,8 +93,8 @@ public func isNotNil <A> (_ x: A?) -> Bool {
 public func == <A: Equatable> (lhs: [A?], rhs: [A?]) -> Bool {
   guard lhs.count == rhs.count else { return false }
 
+  // swiftlint:disable:next reduce_boolean
   return zip(lhs, rhs).reduce(true) { (accum, lr) in
-    // swiftlint:disable:next reduce_boolean
     return accum && lr.0 == lr.1
   }
 }

--- a/bin/test
+++ b/bin/test
@@ -8,7 +8,7 @@ if [ $# -eq 0 ]; then
 fi
 
 if [ "$1" == "iOS" ] || [ "$1" == "UIKit-iOS" ]; then
-  DESTINATION='platform=iOS Simulator,name=iPhone 11,OS='
+  DESTINATION='platform=iOS Simulator,name=iPhone 8,OS='
 else
   DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p,OS='
 fi

--- a/bin/test
+++ b/bin/test
@@ -8,7 +8,7 @@ if [ $# -eq 0 ]; then
 fi
 
 if [ "$1" == "iOS" ] || [ "$1" == "UIKit-iOS" ]; then
-  DESTINATION='platform=iOS Simulator,name=iPhone 6,OS='
+  DESTINATION='platform=iOS Simulator,name=iPhone 11,OS='
 else
   DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p,OS='
 fi

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.1.0"
+      xcode: "11.3.0"
     working_directory: ~/Kickstarter-Prelude
     environment:
       CIRCLE_ARTIFACTS: /tmp
@@ -18,10 +18,10 @@ jobs:
       - run: set -o pipefail &&
              swiftlint lint --strict --reporter json |
              tee $CIRCLE_ARTIFACTS/swiftlint-report.json
-      - run: bin/test iOS 11.2
-      - run: bin/test iOS 12.1
-      - run: bin/test UIKit-iOS 11.2
-      - run: bin/test UIKit-iOS 12.1
+      - run: bin/test iOS 12.4
+      - run: bin/test iOS 13.3
+      - run: bin/test UIKit-iOS 12.4
+      - run: bin/test UIKit-iOS 13.3
 
       - store_artifacts:
           path: /tmp/swiftlint-report.json


### PR DESCRIPTION
Does:

- Updates Prelude to compile in Xcode 11 and Swift 5.1
- Adds two overrides for lenses to fix an ambiguity regression that showed up in the app.
- Removes some of the compiler checks that were previously in place to support certain types on iOS/tvOs, some are no longer needed.

Does not:

Silence all warnings. In an effort to reduce the size of the PR I have left most warnings alone for now. Most were just related to redundant use of public modifiers in extensions, etc.